### PR TITLE
userscript: Move to new JS module name

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,7 +34,7 @@ Please connect to the cdc-sink diagnostic endpoint at `/_/diag` and include the 
 If running a custom user-script, please add it here:
 
 ```
-import * as api from "cdc-sink@v1";
+import * as api from "replicator@v1";
 ....
 ```
 

--- a/internal/script/applier.go
+++ b/internal/script/applier.go
@@ -51,9 +51,9 @@ func notInTransaction() error {
 	return errors.New("no transaction is currently open")
 }
 
-// applier implements [types.TableAcceptor] to allow user-defined functions to
-// be used to interact with the database, rather than using cdc-sink's
-// built-in SQL.
+// applier implements [types.TableAcceptor] to allow user-defined
+// functions to be used to interact with the database, rather than using
+// Replicator's built-in SQL.
 type applier struct {
 	apply  applyJS
 	parent *UserScript

--- a/internal/script/help_command.go
+++ b/internal/script/help_command.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	//go:embed testdata/cdc-sink@v1.d.ts
+	//go:embed testdata/replicator@v1.d.ts
 	bindings string
 	//go:embed testdata/main.ts
 	example string
@@ -32,7 +32,7 @@ var (
 
 const help = `
 A userscript is a JavaScript / TypeScript program that allows arbitrary
-logic to be injected into cdc-sink. It is especially useful in cases
+logic to be injected into Replicator. It is especially useful in cases
 where the source data does not map directly onto SQL tables (e.g.
 migrations from a document store).
 
@@ -61,7 +61,7 @@ func HelpCommand() *cobra.Command {
 				return
 			}
 			fmt.Print(help)
-			fmt.Print("\n\n===== VVV cdc-sink@v1.d.ts VVV =====\n\n")
+			fmt.Print("\n\n===== VVV replicator@v1.d.ts VVV =====\n\n")
 			fmt.Print(bindings)
 			fmt.Print("\n\n===== VVV example-userscript.ts VVV ===== \n\n")
 			fmt.Print(example)

--- a/internal/script/loader.go
+++ b/internal/script/loader.go
@@ -138,7 +138,7 @@ type targetJS struct {
 // target schema, call [Loader.Bind] to return a [UserScript] that
 // operates within the given target schema.
 type Loader struct {
-	apiModule    *goja.Object          // The imported cdc-sink module.
+	apiModule    *goja.Object          // The imported replicator module.
 	applyConfigs *applycfg.Configs     // Injected.
 	diags        *diag.Diagnostics     // Injected.
 	fs           fs.FS                 // Used by require.

--- a/internal/script/provider.go
+++ b/internal/script/provider.go
@@ -89,7 +89,8 @@ func ProvideLoader(
 	// Populate an object that represents the API used by scripts.
 	apiModule := l.rt.NewObject()
 	l.apiModule = apiModule
-	l.requireCache["cdc-sink@v1"] = apiModule
+	l.requireCache["cdc-sink@v1"] = apiModule // Legacy compatibility.
+	l.requireCache["replicator@v1"] = apiModule
 	if err := apiModule.Set("configureSource", l.configureSource); err != nil {
 		return nil, err
 	}

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -122,7 +122,7 @@ type UserScript struct {
 	Sources  *ident.Map[*Source]
 	Targets  *ident.TableMap[*Target]
 
-	apiModule *goja.Object         // The cdc-sink JS module.
+	apiModule *goja.Object         // The Replicator JS module.
 	rt        *goja.Runtime        // The JavaScript VM. See execJS.
 	rtExit    notify.Var[struct{}] // Forms an ersatz event loop for checking promise status.
 	rtMu      *sync.RWMutex        // Serialize access to the VM or its side-effects.

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -302,7 +302,7 @@ CREATE TABLE %s.skewed_merge_times(
 		// the script to be able to load individual records using only
 		// the PK would improve the ergonomics.
 		//
-		// https://github.com/cockroachdb/cdc-sink/issues/705
+		// https://github.com/cockroachdb/replicator/issues/705
 		tx, err := fixture.TargetPool.BeginTx(ctx, nil)
 		r.NoError(err)
 		defer func() { _ = tx.Rollback() }()
@@ -415,4 +415,22 @@ CREATE TABLE %s.skewed_merge_times(
 			))
 		}
 	})
+}
+
+// This test ensures that the old name continues to function.
+func TestLegacyImport(t *testing.T) {
+	r := require.New(t)
+
+	fixture, err := all.NewFixture(t)
+	r.NoError(err)
+
+	ctx := fixture.Context
+	var opts mapOptions
+	cfg := &Config{
+		Options:        &opts,
+		UserScriptPath: "./testdata/legacy_import.ts",
+	}
+	_, err = ProvideLoader(ctx, fixture.Configs, cfg, fixture.Diagnostics)
+	r.NoError(err)
+	r.Equal(map[string]string{"old": "world"}, opts.data)
 }

--- a/internal/script/testdata/legacy_import.ts
+++ b/internal/script/testdata/legacy_import.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 The Cockroach Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Ensure old import path continues to work.
+import * as legacy from "cdc-sink@v1";
+
+legacy.setOptions({"old": "world"});

--- a/internal/script/testdata/main.ts
+++ b/internal/script/testdata/main.ts
@@ -16,8 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as api from "cdc-sink@v1"; // Well-known module name
-import {ApplyOp} from "cdc-sink@v1"; // Verify additional code imports.
+import * as api from "replicator@v1"; // Well-known module name
+import {ApplyOp} from "replicator@v1"; // Verify additional code imports.
 import externalData from "./data.txt"; // Can import additional files from disk.
 import * as lib from "./lib";
 // import * as something from "https://some.cdn/package@1" is viable
@@ -172,8 +172,8 @@ api.configureTable("skewed_merge_times", {
 // copied into a replacement upsert operation.
 //
 // The ergonomics of this could be improved by one or both of:
-// https://github.com/cockroachdb/cdc-sink/issues/704
-// https://github.com/cockroachdb/cdc-sink/issues/705
+// https://github.com/cockroachdb/replicator/issues/704
+// https://github.com/cockroachdb/replicator/issues/705
 api.configureTable("soft_deletes", {
     apply: async (ops: ApplyOp[]): Promise<any> => {
         ops = ops.map((op: ApplyOp) => {

--- a/internal/script/testdata/replicator@v1.d.ts
+++ b/internal/script/testdata/replicator@v1.d.ts
@@ -18,12 +18,12 @@
 
 
 /**
- * The user-script API provided by cdc-sink.
+ * The user-script API provided by Replicator.
  *
  * The contents of this file can be retrieved by running
- * `cdc-sink userscript --api`.
+ * `replicator userscript --api`.
  */
-declare module "cdc-sink@v1" {
+declare module "replicator@v1" {
     /**
      * The name of a SQL column.
      */
@@ -133,7 +133,7 @@ declare module "cdc-sink@v1" {
      *
      * @param tableName - The name of the table.
      * @param props - Properties to configure the table.
-     * @see https://github.com/cockroachdb/cdc-sink#data-application-behaviors
+     * @see https://github.com/cockroachdb/replicator#data-application-behaviors
      */
     function configureTable(
         tableName: Table,
@@ -167,7 +167,7 @@ declare module "cdc-sink@v1" {
      */
     type ConfigureTableOptions = {
         /**
-         * Override cdc-sink's default apply behavior. The userscript
+         * Override Replicator's default apply behavior. The userscript
          * assumes responsibility for interacting with the target
          * database. Access to the target database is provided via
          * {@link getTX}.
@@ -295,7 +295,7 @@ declare module "cdc-sink@v1" {
     type StandardMerge = {};
 
     /**
-     * A TargetColumn provides a view of cdc-sink's introspection of a
+     * A TargetColumn provides a view of Replicator's introspection of a
      * table in the destination database.
      */
     type TargetColumn = {
@@ -304,7 +304,7 @@ declare module "cdc-sink@v1" {
          */
         defaultExpr?: string;
         /**
-         * True if the column wouldn't normally be operated on by cdc-sink.
+         * True if the column wouldn't normally be operated on by Replicator.
          */
         ignored: boolean;
         /**
@@ -328,7 +328,7 @@ declare module "cdc-sink@v1" {
     type TargetTX = {
         /**
          * Apply the operations to the target table. This allows the
-         * userscript to invoke cdc-sink's default apply pipeline (with
+         * userscript to invoke Replicator's default apply pipeline (with
          * all data behaviors).
          */
         apply(ops: ApplyOp[]): Promise<void>;

--- a/internal/script/testdata/tsconfig.json
+++ b/internal/script/testdata/tsconfig.json
@@ -1,4 +1,4 @@
-// This improves code introspection in GoLand. It's not used by cdc-sink
+// This improves code introspection in GoLand. It's not used by Replicator
 // code itself.
 {
   "compilerOptions": {

--- a/internal/sequencer/script/script_test.go
+++ b/internal/sequencer/script/script_test.go
@@ -78,7 +78,7 @@ func testUserScriptSequencer(t *testing.T, baseMode switcher.Mode) {
 		MainPath: "/main.ts",
 		FS: &fstest.MapFS{
 			"main.ts": &fstest.MapFile{Data: []byte(`
-import * as api from "cdc-sink@v1";
+import * as api from "replicator@v1";
 api.configureSource("src1", {
   dispatch: (doc) => ({
     "T_1": [ doc ], // Note upper-case table name.

--- a/internal/source/cdc/server/injector_test.go
+++ b/internal/source/cdc/server/injector_test.go
@@ -37,7 +37,7 @@ func TestScriptConfigureTarget(t *testing.T) {
 	r.NoError(err)
 
 	tsFile := fmt.Sprintf(`
-import * as api from "cdc-sink@v1";
+import * as api from "replicator@v1";
 api.setOptions({
   "bindAddr": "127.0.0.1:0",
   "stagingSchema": %q,

--- a/scripts/active_active/README.md
+++ b/scripts/active_active/README.md
@@ -216,8 +216,8 @@ The `repl.ts` module, used by `west.ts` (both script must be in the same directo
 `cdc-sink` is started):
 
 ```javascript
-import * as api from "cdc-sink@v1";
-import { ApplyOp } from "cdc-sink@v1";
+import * as api from "replicator@v1";
+import { ApplyOp } from "replicator@v1";
 export function replicateTo(target: string, tables: string[]) {
     for (let table of tables) {
         console.log("Configuring replication for " + table)

--- a/scripts/active_active/userscripts/cdc-sink@v1.d.ts
+++ b/scripts/active_active/userscripts/cdc-sink@v1.d.ts
@@ -1,1 +1,0 @@
-../../../internal/script/testdata/cdc-sink@v1.d.ts

--- a/scripts/active_active/userscripts/repl.ts
+++ b/scripts/active_active/userscripts/repl.ts
@@ -16,8 +16,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-import * as api from "cdc-sink@v1";
-import { ApplyOp } from "cdc-sink@v1";
+import * as api from "replicator@v1";
+import { ApplyOp } from "replicator@v1";
 
  /**
  * Configure a replication flow. It assumes that each incoming

--- a/scripts/active_active/userscripts/replicator@v1.d.ts
+++ b/scripts/active_active/userscripts/replicator@v1.d.ts
@@ -1,0 +1,1 @@
+../../../internal/script/testdata/replicator@v1.d.ts

--- a/scripts/active_active/userscripts/tsconfig.json
+++ b/scripts/active_active/userscripts/tsconfig.json
@@ -9,7 +9,7 @@
       "moduleResolution": "node",
       "baseUrl": ".",
       "paths": {
-          "cdc-sink@v1": ["cdc-sink@v1.d.ts"]
+          "replicator@v1": ["replicator@v1.d.ts"]
         }
     }
 }


### PR DESCRIPTION
This change replaces the use of `cdc-sink@v1` with `replicator@v1`. Compatibility with existing scripts is retained by allowing the same API object to be imported using the old name. A test is added for this legacy case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/849)
<!-- Reviewable:end -->
