### PR TITLE
Updating the templates, dump and the env variable to be Replicator

### DIFF
--- a/internal/cmd/dumptemplates/dumptemplates.go
+++ b/internal/cmd/dumptemplates/dumptemplates.go
@@ -37,12 +37,12 @@ func Command() *cobra.Command {
 		Short:  "write the query templates to disk (debugging use only)",
 		Long: fmt.Sprintf(`This command writes the apply templates to disk.
 
-When running cdc-sink, set the %[1]s environment variable to the directory
+When running Replicator, set the %[1]s environment variable to the directory
 that is passed to the --path flag. The indicated directory must contain
 a subdirectory named %[2]s.
 
-cdc-sink dumptemplates --path .
-%[1]s=. cdc-sink start ....
+replicator dumptemplates --path .
+%[1]s=. replicator start ....
 `, apply.TemplateOverrideEnv, apply.QueryDir),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return fscopy.Copy(apply.EmbeddedTemplates, path)

--- a/internal/target/apply/queries/crdb/common.tmpl
+++ b/internal/target/apply/queries/crdb/common.tmpl
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+{{- /*gotype: github.com/cockroachdb/replicator/internal/target/apply.templates*/ -}}
 
 {{- /* names produces a comma-separated list of column names: foo, bar, baz*/ -}}
 {{- define "names" -}}

--- a/internal/target/apply/queries/crdb/conditional.tmpl
+++ b/internal/target/apply/queries/crdb/conditional.tmpl
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+{{- /*gotype: github.com/cockroachdb/replicator/internal/target/apply.templates*/ -}}
 {{- /*
 This template implements the conditional update flow (compare-and-set,
 deadlines). For an expanded example, see the templates_test.go file.

--- a/internal/target/apply/queries/crdb/delete.tmpl
+++ b/internal/target/apply/queries/crdb/delete.tmpl
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+{{- /*gotype: github.com/cockroachdb/replicator/internal/target/apply.templates*/ -}}
 {{- /*
 DELETE FROM "database"."schema"."table"
 WHERE ("pk0","pk1") IN (($1,$2), (...), ...)

--- a/internal/target/apply/queries/crdb/toasted.tmpl
+++ b/internal/target/apply/queries/crdb/toasted.tmpl
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+{{- /*gotype: github.com/cockroachdb/replicator/internal/target/apply.templates*/ -}}
 
 WITH data ({{- template "names" .Columns -}} ) AS (
 VALUES{{- nl -}}

--- a/internal/target/apply/queries/crdb/upsert.tmpl
+++ b/internal/target/apply/queries/crdb/upsert.tmpl
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+{{- /*gotype: github.com/cockroachdb/replicator/internal/target/apply.templates*/ -}}
 {{- /*
 UPSERT INTO "database"."schema"."table"
  ("pk0","pk1","val0","val1","geom","geog")

--- a/internal/target/apply/queries/my/common.tmpl
+++ b/internal/target/apply/queries/my/common.tmpl
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+{{- /*gotype: github.com/cockroachdb/replicator/internal/target/apply.templates*/ -}}
 
 {{- /* names produces a comma-separated list of column names: foo, bar, baz*/ -}}
 {{- define "names" -}}
@@ -41,7 +41,7 @@
                 CASE WHEN ? THEN {{- sp -}}
               {{- end -}}
             {{- if $pair.Expr -}}
-                ({{ $pair.Expr }}) 
+                ({{ $pair.Expr }})
             {{- else if eq $pair.Column.Type "geometry" -}}
                 st_geomfromgeojson(?)
             {{- else -}}

--- a/internal/target/apply/queries/my/conditional.tmpl
+++ b/internal/target/apply/queries/my/conditional.tmpl
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+{{- /*gotype: github.com/cockroachdb/replicator/internal/target/apply.templates*/ -}}
 {{- /*
 This template implements the conditional update flow (compare-and-set,
 deadlines). For expanded examples, see the templates_test.go file.
@@ -96,7 +96,7 @@ WHERE current.{{ (index .PK 0).Name }} IS NULL OR
 {{- end -}}{{- /* .Conditions */ -}}
 
 {{- /*
-The last clause is to select the actionable rows 
+The last clause is to select the actionable rows
 to be upserted into the target table.
 SELECT * FROM dataSource
 ON DUPLICATE KEY UPDATE ts=VALUES(ts),  ver=VALUES(ver);
@@ -105,7 +105,7 @@ ON DUPLICATE KEY UPDATE ts=VALUES(ts),  ver=VALUES(ver);
 SELECT * FROM {{ $dataSource }}
 {{- nl -}}
 {{- if .Data -}}
-ON DUPLICATE KEY UPDATE 
+ON DUPLICATE KEY UPDATE
 {{ template "valuelist" .Data }}
 {{- end -}}
 {{- /* Trim whitespace */ -}}

--- a/internal/target/apply/queries/my/delete.tmpl
+++ b/internal/target/apply/queries/my/delete.tmpl
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+{{- /*gotype: github.com/cockroachdb/replicator/internal/target/apply.templates*/ -}}
 {{- /*
 DELETE FROM "database"."schema"."table"
 WHERE ("pk0","pk1") IN ((?,?), (...), ...)

--- a/internal/target/apply/queries/my/upsert.tmpl
+++ b/internal/target/apply/queries/my/upsert.tmpl
@@ -1,8 +1,8 @@
-{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+{{- /*gotype: github.com/cockroachdb/replicator/internal/target/apply.templates*/ -}}
 {{- /*
 
-INSERT INTO "schema"."table" 
-  ("pk0","pk1","val0","val1","geom") 
+INSERT INTO "schema"."table"
+  ("pk0","pk1","val0","val1","geom")
   VALUES ?, ?, ?, ?, st_geomfromgeojson(?)
   ON DUPLICATE KEY UPDATE val0=VALUES(val0),  val1=VALUES(val1),  geom=VALUES(geom);
 
@@ -14,7 +14,7 @@ INTO {{ .TableName }}
 VALUES
 {{ template "exprs" . }}
 {{- if .Data }}
-ON DUPLICATE KEY UPDATE 
+ON DUPLICATE KEY UPDATE
 {{ template "valuelist" .Data }}
 {{- end -}}
 

--- a/internal/target/apply/queries/ora/common.tmpl
+++ b/internal/target/apply/queries/ora/common.tmpl
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+{{- /*gotype: github.com/cockroachdb/replicator/internal/target/apply.templates*/ -}}
 
 {{- /* names produces a comma-separated list of column names: foo, bar, baz*/ -}}
 {{- define "names" -}}
@@ -23,7 +23,7 @@ pairExprs produces a comma-separated list of positional arguments.
 pairExpr emits a type-cast SQL expression for a single positional argument.
 */ -}}
 {{- define "pairExpr" -}}
-    {{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.varPair*/ -}}
+    {{- /*gotype: github.com/cockroachdb/replicator/internal/target/apply.varPair*/ -}}
     {{- $pair := . -}}
     {{- if $pair.Expr -}}
         CAST({{ $pair.Expr }} AS {{ $pair.Column.Type }})

--- a/internal/target/apply/queries/ora/delete.tmpl
+++ b/internal/target/apply/queries/ora/delete.tmpl
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+{{- /*gotype: github.com/cockroachdb/replicator/internal/target/apply.templates*/ -}}
 {{- /*
 DELETE FROM "schema"."table"
 WHERE ("pk0","pk1") IN ((:1,:2), (...), ...)

--- a/internal/target/apply/queries/ora/upsert.tmpl
+++ b/internal/target/apply/queries/ora/upsert.tmpl
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+{{- /*gotype: github.com/cockroachdb/replicator/internal/target/apply.templates*/ -}}
 {{- /*
 This implementation is similar to the PG one, in that we have a number
 of CTEs that define the incoming data and filter it based on CAS or

--- a/internal/target/apply/queries/pg/common.tmpl
+++ b/internal/target/apply/queries/pg/common.tmpl
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+{{- /*gotype: github.com/cockroachdb/replicator/internal/target/apply.templates*/ -}}
 
 {{- /* names produces a comma-separated list of column names: foo, bar, baz*/ -}}
 {{- define "names" -}}

--- a/internal/target/apply/queries/pg/conditional.tmpl
+++ b/internal/target/apply/queries/pg/conditional.tmpl
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+{{- /*gotype: github.com/cockroachdb/replicator/internal/target/apply.templates*/ -}}
 {{- /*
 This template implements the conditional update flow (compare-and-set,
 deadlines). For an expanded example, see the templates_test.go file.

--- a/internal/target/apply/queries/pg/delete.tmpl
+++ b/internal/target/apply/queries/pg/delete.tmpl
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+{{- /*gotype: github.com/cockroachdb/replicator/internal/target/apply.templates*/ -}}
 {{- /*
 DELETE FROM "database"."schema"."table"
 WHERE ("pk0","pk1") IN (($1,$2), (...), ...)

--- a/internal/target/apply/queries/pg/upsert.tmpl
+++ b/internal/target/apply/queries/pg/upsert.tmpl
@@ -1,4 +1,4 @@
-{{- /*gotype: github.com/cockroachdb/cdc-sink/internal/target/apply.templates*/ -}}
+{{- /*gotype: github.com/cockroachdb/replicator/internal/target/apply.templates*/ -}}
 {{- /*
 UPSERT, using INSERT ON CONFLICT DO UPDATE
 

--- a/internal/target/apply/templates.go
+++ b/internal/target/apply/templates.go
@@ -39,8 +39,8 @@ const (
 	// TemplateOverrideEnv is the name of an environment variable that
 	// overrides the [fs.FS] from which the query templates are loaded.
 	// This facilitates ad-hoc debugging of queries, without the need to
-	// recompile the cdc-sink binary.
-	TemplateOverrideEnv = "CDC_SINK_TEMPLATES"
+	// recompile the Replicator binary.
+	TemplateOverrideEnv = "REPLICATOR_TEMPLATES"
 )
 
 var (

--- a/internal/target/apply/testdata/my/base.upsert.sql
+++ b/internal/target/apply/testdata/my/base.upsert.sql
@@ -3,5 +3,5 @@ INSERT INTO "schema"."table"
 VALUES
 (?,?,?,?,CASE WHEN ? THEN ? ELSE expr() END),
 (?,?,?,?,CASE WHEN ? THEN ? ELSE expr() END)
-ON DUPLICATE KEY UPDATE 
+ON DUPLICATE KEY UPDATE
 "val0"=VALUES("val0"),"val1"=VALUES("val1"),"has_default"=VALUES("has_default")

--- a/internal/target/apply/testdata/my/cas.upsert.sql
+++ b/internal/target/apply/testdata/my/cas.upsert.sql
@@ -16,5 +16,5 @@ USING ("pk0","pk1")
 WHERE current."pk0" IS NULL OR
 (data."val1",data."val0") > (current."val1",current."val0"))
 SELECT * FROM action
-ON DUPLICATE KEY UPDATE 
+ON DUPLICATE KEY UPDATE
 "val0"=VALUES("val0"),"val1"=VALUES("val1"),"has_default"=VALUES("has_default")

--- a/internal/target/apply/testdata/my/casDeadline.upsert.sql
+++ b/internal/target/apply/testdata/my/casDeadline.upsert.sql
@@ -17,5 +17,5 @@ USING ("pk0","pk1")
 WHERE current."pk0" IS NULL OR
 (deadlined."val1",deadlined."val0") > (current."val1",current."val0"))
 SELECT * FROM action
-ON DUPLICATE KEY UPDATE 
+ON DUPLICATE KEY UPDATE
 "val0"=VALUES("val0"),"val1"=VALUES("val1"),"has_default"=VALUES("has_default")

--- a/internal/target/apply/testdata/my/deadline.upsert.sql
+++ b/internal/target/apply/testdata/my/deadline.upsert.sql
@@ -6,5 +6,5 @@ WITH data  ("pk0","pk1","val0","val1","has_default") AS (
 ),
 deadlined AS (SELECT * FROM data WHERE("val0"> now()- INTERVAL '3600' SECOND)AND("val1"> now()- INTERVAL '1' SECOND))
 SELECT * FROM deadlined
-ON DUPLICATE KEY UPDATE 
+ON DUPLICATE KEY UPDATE
 "val0"=VALUES("val0"),"val1"=VALUES("val1"),"has_default"=VALUES("has_default")

--- a/internal/target/apply/testdata/my/expr.upsert.sql
+++ b/internal/target/apply/testdata/my/expr.upsert.sql
@@ -3,5 +3,5 @@ INSERT INTO "schema"."table"
 VALUES
 (?,(?+?),('fixed'),(?||'foobar'),CASE WHEN ? THEN ? ELSE expr() END),
 (?,(?+?),('fixed'),(?||'foobar'),CASE WHEN ? THEN ? ELSE expr() END)
-ON DUPLICATE KEY UPDATE 
+ON DUPLICATE KEY UPDATE
 "val0"=VALUES("val0"),"val1"=VALUES("val1"),"has_default"=VALUES("has_default")

--- a/internal/target/apply/testdata/my/ignore.upsert.sql
+++ b/internal/target/apply/testdata/my/ignore.upsert.sql
@@ -3,5 +3,5 @@ INSERT INTO "schema"."table"
 VALUES
 (?,?,CASE WHEN ? THEN ? ELSE expr() END),
 (?,?,CASE WHEN ? THEN ? ELSE expr() END)
-ON DUPLICATE KEY UPDATE 
+ON DUPLICATE KEY UPDATE
 "has_default"=VALUES("has_default")

--- a/internal/target/apply/testdata/my/source names.upsert.sql
+++ b/internal/target/apply/testdata/my/source names.upsert.sql
@@ -3,5 +3,5 @@ INSERT INTO "schema"."table"
 VALUES
 (?,?,?,?,CASE WHEN ? THEN ? ELSE expr() END),
 (?,?,?,?,CASE WHEN ? THEN ? ELSE expr() END)
-ON DUPLICATE KEY UPDATE 
+ON DUPLICATE KEY UPDATE
 "val0"=VALUES("val0"),"val1"=VALUES("val1"),"has_default"=VALUES("has_default")


### PR DESCRIPTION
The env variable is now `REPLICATOR_TEMPLATES` instead of `CDC_SINK_TEMPLATES`. I doubt that this is commonly used at this point, but if you think it's necessary, I can add a check for the legacy value and just throw an error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/853)
<!-- Reviewable:end -->
