### PR TITLE
workflows: Refresh binary distributions

### DIFF
--- a/.github/workflows/go-binaries.yaml
+++ b/.github/workflows/go-binaries.yaml
@@ -14,26 +14,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Binaries will build cdc-sink for a variety of common platforms and
+# Binaries will build Replicator for a variety of common platforms and
 # optionally push the results to a GCP bucket.
 name: Golang Binaries
 permissions:
   contents: read
+  id-token: write
   statuses: write
 on:
   workflow_call:
-    inputs:
-      push:
-        default: false
-        description: Upload binaries to GCP bucket
-        required: true
-        type: boolean
   workflow_dispatch:
-    inputs:
-      push:
-        default: true
-        description: Upload binaries to GCP bucket
-        type: boolean
 
 jobs:
   binaries:
@@ -65,100 +55,50 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Pick up a symbolic name for the build (e.g. "v1.0.1") and a guaranteed SHA or tag value.
-      - id: names
-        name: Determine versions and names
-        run: |
-          BUILDNAME="cdc-sink-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.target && format('-{0}', matrix.target) || '' }}"   # cdc-sink-linux-amd64[-target]
-          OUTPUT="cdc-sink${{ matrix.ext }}"                         # cdc-sink(.exe)
-          VERSION=$(git describe --tags --always --dirty)            # Tag name or SHA 
-          SYMBOLIC_NAME=$(                                           # Tag, branch, or SHA.
-            git describe --tags --exact-match HEAD 2> /dev/null ||
-            git symbolic-ref -q --short HEAD ||
-            echo "$VERSION")
-          SYMBOLIC_NAME=$(echo $SYMBOLIC_NAME | tr / -) # Replaces slashes in branch name
-          
-          # These are file globs to be included in the tarball.
-          DISTRO_PATHS=$(cat << EOF
-          $OUTPUT
-          README.md
-          VERSION.txt
-          licenses/*.txt
-          EOF)
-          
-          # Write a build-marker file for convenience.
-          echo "$VERSION" > VERSION.txt
-
-          # Export values into next build steps.          
-          echo "BUILDNAME=$BUILDNAME" >> $GITHUB_ENV
-          echo "DISTRO_NAME=$BUILDNAME-$SYMBOLIC_NAME" >> $GITHUB_ENV          
-          echo "OUTPUT=$OUTPUT" >> $GITHUB_ENV
-          echo "SYMBOLIC_NAME=$SYMBOLIC_NAME" >> $GITHUB_ENV
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          
-          # Special handling since this is a multiline string
-          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
-          echo "DISTRO_PATHS<<EOF" >> $GITHUB_ENV
-          echo "$DISTRO_PATHS" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-
       - id: setup_go
         name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
 
-      - id: licenses
-        name: Bundle license files
-        run: go generate ./internal/cmd/licenses
-
-      - id: build
-        name: Build
-        run: >
-          go
-          build
-          -v
-          -ldflags="-s -w"
-          ${{ matrix.target && format('-tags target_{0}', matrix.target) || '' }}
-          -o $OUTPUT
-          .
+      - id: package
         env:
-          CGO_ENABLED: ${{ matrix.cgo || '0' }}
-          GOOS: ${{ matrix.os }}
-          GOARCH: ${{ matrix.arch }}
-
-      - id: tarball
-        name: Create distribution tarball
-        run: |
-          # Expand globs with the find command. The output from find
-          # will have a ./ at the beginning.  We'll replace that when
-          # packing the archive with the distribution name.
-          echo "${{ env.DISTRO_PATHS }}" |
-          xargs -rIQ find . -path ./Q  -print0 |
-          xargs -r0 tar zcvf ${{ env.DISTRO_NAME }}.tgz --transform 's|^./|${{ env.DISTRO_NAME }}/|'
+          # replicator-linux-amd64[-target]
+          PACKAGE_NAME: "replicator-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.target && format('-{0}', matrix.target) || '' }}"
+          PACKAGE_BIN_NAME: "replicator${{ matrix.ext }}" # replicator.exe
+          PACKAGE_BUILD_FLAGS: ${{ matrix.target && format('-tags target_{0}', matrix.target) || '' }}
+          PACKAGE_CGO_ENABLED: ${{ matrix.cgo || '0' }}
+          PACKAGE_GOOS: ${{ matrix.os }}
+          PACKAGE_GOARCH: ${{ matrix.arch }}
+          UPLOAD_DIR: upload
+        run: ./.github/workflows/package.sh
 
       - id: auth
         name: Authenticate to GCP
         # Only authenticate if we're on the main repo (i.e. have access
-        # to the secret) and we're pushing to a branch. Manual runs are
-        # also allowed as a convenience.
-        if: ${{ inputs.push }}
+        # to the secret).
+        if: "${{ vars.GCP_SERVICE_ACCOUNT }}"
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.CDC_SINK_BINARIES_KEY }}
+          workload_identity_provider: "${{ vars.WORKLOAD_IDENTITY_PROVIDER }}"
+          service_account: "${{ vars.GCP_SERVICE_ACCOUNT }}"
 
       - id: upload
         uses: google-github-actions/upload-cloud-storage@v2
-        if: ${{ inputs.push }}
+        if: "${{ steps.auth.outputs.auth_token }}"
         with:
-          path: ${{ env.DISTRO_NAME }}.tgz
-          destination: ${{ vars.CDC_SINK_BUCKET }}/
+          path: "upload/"
+          parent: false # Don't include the upload directory name
+          destination: ${{ vars.REPLICATOR_BUCKET }}/
           process_gcloudignore: false # Suppress warning about missing .gcloudignore file
 
       - id: link
         name: Summary link
-        if: ${{ inputs.push }}
-        run: echo "[${{ env.BUILDNAME }}](https://storage.googleapis.com/${{ vars.CDC_SINK_BUCKET }}/${{ env.DISTRO_NAME }}.tgz)" >> $GITHUB_STEP_SUMMARY
+        if: "${{ steps.upload.outputs.uploaded }}"
+        run: |
+          for f in "${{ steps.upload.outputs.uploaded }}"; do
+            echo "[$(basename $f)](https://replicator.cockroachdb.com/$f)" >> $GITHUB_STEP_SUMMARY
+          done
 
   # Aggregate the results of multiple jobs within this workflow into a
   # single status object that we can use for branch protection.

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -44,11 +44,9 @@ jobs:
       - go-build-cache
     permissions:
       contents: read
+      id-token: write
       statuses: write
     secrets: inherit
-    with:
-      # Push if we're in the main repo and are pushing to a branch selected above.
-      push: ${{ !github.event.pull_request.head.repo.fork && github.event_name == 'push' }}
 
   go-codeql:
     uses: ./.github/workflows/go-codeql.yaml
@@ -90,5 +88,5 @@ jobs:
       contents: write
     secrets: inherit
     with:
-      # Only update the wiki if we're pushing to the master branch.
-      push: ${{ github.event.push.ref == 'refs/heads/master' }}
+      # Only update the wiki if we're merging into the master branch.
+      push: ${{ github.event.merge_group.base_ref == 'refs/heads/master' }}

--- a/.github/workflows/package.sh
+++ b/.github/workflows/package.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Copyright 2024 The Cockroach Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# This shell script is intended to be executed from the root of the
+# repository. It will create an output folder to be uploaded to a
+# storage bucket. This exists outside of the workflow file to aid
+# in local testing.
+
+set -ex
+
+# Variables that may be set by the workflow.
+PACKAGE_NAME=${PACKAGE_NAME:-replicator-local-dev} # replicator-linux-amd64[-target]
+PACKAGE_BIN_NAME=${PACKAGE_BIN_NAME:-replicator}   # replicator(.exe)
+UPLOAD_DIR=${UPLOAD_DIR:-upload}   # upload/
+EDGE_DIR="$UPLOAD_DIR/edge"
+
+# Temp dir.
+WORK_DIR=$(mktemp -d)
+
+# Extract names from git checkout.
+SHORT_VERSION=$(git rev-parse --short HEAD)                                 # Short SHA
+TAG_VERSION=$(git describe --tags --exact-match HEAD 2> /dev/null || true ) # v1.0.1
+BRANCH_NAME=$( (git symbolic-ref -q --short HEAD | tr / -) || true )        # Replace slashes in branch name
+
+# Bundle license files
+go generate ./internal/cmd/licenses
+
+# Build main binary
+# We want the build flags to fully expand
+# shellcheck disable=SC2086
+CGO_ENABLED=$PACKAGE_CGO_ENABLED \
+GOOS=$PACKAGE_GOOS \
+GOARCH=$PACKAGE_GOARCH \
+go build -v -ldflags="-s -w" $PACKAGE_BUILD_FLAGS -o "$WORK_DIR/$PACKAGE_BIN_NAME" .
+
+echo "$SHORT_VERSION" > "$WORK_DIR/VERSION.txt"
+
+# Package into a temporary file. We use the transform option to add an
+# extra path element to the files within the archive.
+tar zcvf "$WORK_DIR/package.tgz" --transform "s|^.*/|./$PACKAGE_NAME/|" "$WORK_DIR/$PACKAGE_BIN_NAME" ./README.md "$WORK_DIR/VERSION.txt"
+
+mkdir -p "$EDGE_DIR/sha" "$EDGE_DIR/branch"
+cp "$WORK_DIR/package.tgz" "$EDGE_DIR/sha/$PACKAGE_NAME-$SHORT_VERSION.tgz"
+if [ -n "$BRANCH_NAME" ]; then
+  cp "$WORK_DIR/package.tgz" "$EDGE_DIR/branch/$PACKAGE_NAME-$BRANCH_NAME.tgz"
+fi
+TAG_REGEX="^v[0-9]+\.[0-9]+\.[0-9]+$"
+if [[ "$TAG_VERSION" =~ $TAG_REGEX ]]; then
+  cp "$WORK_DIR/package.tgz" "$UPLOAD_DIR/$PACKAGE_NAME-$TAG_VERSION.tgz"
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ replicator
 cockroach-data/
 goroutine_dump/
 heap_profiler/
+
+# Package working directory
+upload/
+


### PR DESCRIPTION
This change migrates to the new replicator.cockroachdb.com storage bucket.
Tarballs are pushed to an `edge/sha/` path prefix on every build. Branch builds
are pushed to an `edge/branch/` path. Version tags will be pushed to the top
level of the bucket. As before, links to the uploaded file(s) will be reported
as a workflow status message.

The bulk of the shell code is pulled out into a separate file so that it may be
run locally for testing.

h/t to @rail for Workload Identity Federation setup

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/855)
<!-- Reviewable:end -->
