### PR TITLE
workflow: Fix upload links when multiple tarballs are created

### DIFF
--- a/.github/workflows/go-binaries.yaml
+++ b/.github/workflows/go-binaries.yaml
@@ -95,8 +95,10 @@ jobs:
       - id: link
         name: Summary link
         if: "${{ steps.upload.outputs.uploaded }}"
+        env:
+          UPLOAD_PATHS: ${{ steps.upload.outputs.uploaded }}
         run: |
-          for f in "${{ steps.upload.outputs.uploaded }}"; do
+          for f in ${UPLOAD_PATHS//,/ }; do # Split comma-separated list
             echo "[$(basename $f)](https://replicator.cockroachdb.com/$f)" >> $GITHUB_STEP_SUMMARY
           done
 


### PR DESCRIPTION
The output from the uploads step is a comma-separated list. This splits the value to produce multiple links when appropriate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/857)
<!-- Reviewable:end -->
