### PR TITLE
leases: Fix race condition in test code

### DIFF
--- a/internal/staging/leases/leases.go
+++ b/internal/staging/leases/leases.go
@@ -360,6 +360,12 @@ func (l *leases) acquire(
 	return
 }
 
+// copy is used by test code to return a shallow copy of the receiver.
+func (l *leases) copy() *leases {
+	cpy := *l
+	return &cpy
+}
+
 // SQL template to claim a lease
 //
 //	$1 = name

--- a/internal/staging/leases/leases_test.go
+++ b/internal/staging/leases/leases_test.go
@@ -145,9 +145,8 @@ func TestLeases(t *testing.T) {
 		a := assert.New(t)
 
 		// Increase polling rate for this test.
-		oldCfg := l.cfg
+		l := l.copy()
 		l.cfg.Poll = 10 * time.Millisecond
-		defer func() { l.cfg = oldCfg }()
 
 		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
@@ -207,10 +206,9 @@ func TestLeases(t *testing.T) {
 		a := assert.New(t)
 
 		// Increase polling rate.
-		oldCfg := l.cfg
+		l := l.copy()
 		l.cfg.Lifetime = 100 * time.Millisecond
 		l.cfg.Poll = 5 * time.Millisecond
-		defer func() { l.cfg = oldCfg }()
 
 		initial, ok, err := l.acquire(ctx, t.Name())
 		a.NoError(err)
@@ -243,13 +241,11 @@ func TestLeases(t *testing.T) {
 	t.Run("singleton", func(t *testing.T) {
 		a := assert.New(t)
 
-		oldCfg := l.cfg
 		// Ensure that cancel and cleanup are working; the lease
 		// lifetime will be longer than that of the test.
+		l := l.copy()
 		l.cfg.Lifetime = time.Hour
-		// Increase polling rate.
 		l.cfg.Poll = 5 * time.Millisecond
-		defer func() { l.cfg = oldCfg }()
 
 		ctx, cancel := context.WithTimeout(ctx, time.Minute)
 		defer cancel()


### PR DESCRIPTION
The tests in this package need to adjust timeouts and polling intervals. The existing tests are subject to a race condition during cleanup. This change creates a shallow copy before adjusting the configuration, so no deferred restoration is necessary.

Fixes #867

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/868)
<!-- Reviewable:end -->
