### PR TITLE
schemawatch: Add hex-escaped UUID parse helper for Oracle

### DIFF
--- a/internal/target/schemawatch/parse_helpers.go
+++ b/internal/target/schemawatch/parse_helpers.go
@@ -53,6 +53,14 @@ var (
 				if !ok {
 					return nil, errors.Errorf("expecting string, got %T", a)
 				}
+				// If the source UUID is stored as bytes and not as a
+				// UUID type, it will appear in the changefeed as a
+				// hex-escaped string. We can strip the escape sequence
+				// since the UUID parser will accept a 32-character hex
+				// sequence.
+				if len(s) == 34 && s[:2] == `\x` {
+					s = s[2:]
+				}
 				u, err := uuid.Parse(s)
 				return u[:], err
 			},

--- a/internal/target/schemawatch/parse_helpers_test.go
+++ b/internal/target/schemawatch/parse_helpers_test.go
@@ -17,6 +17,7 @@
 package schemawatch
 
 import (
+	"encoding/hex"
 	"fmt"
 	"testing"
 	"time"
@@ -28,7 +29,8 @@ import (
 
 func TestOraParseHelpers(t *testing.T) {
 	now := time.Now().UTC()
-
+	exampleUUIDString := "C847E52A-2612-4B98-9835-B0F0A9FCCD2F"
+	exampleUUID := uuid.MustParse(exampleUUIDString)
 	tcs := []struct {
 		typ      string
 		input    any
@@ -36,11 +38,16 @@ func TestOraParseHelpers(t *testing.T) {
 	}{
 		{
 			typ:   "RAW(16)",
-			input: "C847E52A-2612-4B98-9835-B0F0A9FCCD2F",
+			input: exampleUUIDString,
 			expected: func() []byte {
-				u := uuid.MustParse("C847E52A-2612-4B98-9835-B0F0A9FCCD2F")
-				// Can't slice without assignment to storage location.
-				return u[:]
+				return exampleUUID[:]
+			}(),
+		},
+		{
+			typ:   "RAW(16)",
+			input: `\x` + hex.EncodeToString(exampleUUID[:]),
+			expected: func() []byte {
+				return exampleUUID[:]
 			}(),
 		},
 		{


### PR DESCRIPTION
If a UUID is stored in the source as a BYTEA type, it will appear within a changefeed as a hex-encoded string with a two-byte prefix. This change looks for this pattern and makes the value decodable by our UUID library by stripping the prefix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/880)
<!-- Reviewable:end -->
