### PR TITLE
notify: Add Var.Swap method

### DIFF
--- a/internal/util/notify/var.go
+++ b/internal/util/notify/var.go
@@ -114,6 +114,18 @@ func (v *Var[T]) Set(next T) <-chan struct{} {
 	return v.mu.updated
 }
 
+// Swap returns the current value and a channel that will be closed
+// when the next value has been replaced.
+func (v *Var[T]) Swap(next T) (T, <-chan struct{}) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	ret := v.mu.data
+	v.mu.data = next
+	v.notifyLocked()
+	return ret, v.mu.updated
+}
+
 // Update atomically updates the stored value using the current value as
 // an input. The callback may return [ErrNoUpdate] to take no action;
 // this error will not be returned to the caller. If the callback

--- a/internal/util/notify/var_test.go
+++ b/internal/util/notify/var_test.go
@@ -115,6 +115,18 @@ func TestVar(t *testing.T) {
 	case <-time.After(time.Second):
 		r.Fail("channel should be closed")
 	}
+
+	// Check swap behavior.
+	current, ch4a := v.Swap(3)
+	r.Equal(2, current)
+	select {
+	case <-ch4a:
+		r.Fail("channel should not be closed")
+	default:
+	}
+	current, ch4b := v.Get()
+	r.Equal(3, current)
+	r.Equal(ch4a, ch4b)
 }
 
 func TestVarOf(t *testing.T) {


### PR DESCRIPTION
This change adds a more straightforward way of swapping the current value of a notify.Var without having to call the Update method.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/882)
<!-- Reviewable:end -->
