### PR TITLE
workflow: Add cockroach-unstable to test matrix

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -81,6 +81,12 @@ services:
     entrypoint: /cockroach/cockroach
     command: start-single-node --insecure --store type=mem,size=2G
 
+  cockroachdb-unstable:
+    image: cockroachdb/cockroach-unstable:latest
+    network_mode: host
+    entrypoint: /cockroach/cockroach
+    command: start-single-node --insecure --store type=mem,size=2G
+
   # This target exists to verify split-mode operation, where staging is separate from the target.
   target-cockroachdb-v23.2:
     image: cockroachdb/cockroach:latest-v23.2

--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -73,6 +73,7 @@ jobs:
   tests:
     name: Integration Tests
     runs-on: ${{ matrix.runs-on || 'ubuntu-latest-8-core' }}
+    continue-on-error: ${{ matrix.experimental || false }}
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -92,6 +93,10 @@ jobs:
           # These are our primary supported versions.
           - cockroachdb: v23.2
           - cockroachdb: v23.1
+
+          # Builds that are allowed to fail.
+          - cockroachdb: unstable
+            experimental: true
 
           # Run a test with a separate CockroachDB source and target
           # instance to ensure there are no accidental dependencies


### PR DESCRIPTION
This change runs tests against the cockroach-unstable image, with the caveat that the job may fail without breaking the build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/884)
<!-- Reviewable:end -->
