### PR TITLE
workflows: Remove dependabot automerge

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -41,9 +41,3 @@ jobs:
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Enable auto-merge for Golang Dependabot PRs
-        if: ${{ steps.metadata.outputs.package-ecosystem == 'go_modules' }}
-        run: gh pr merge --auto --merge "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
The auto-merge recipe now requires the use of a Personal Access Token; the use of GITHUB_TOKEN won't allow the dependent workflows in the merge queue to actually get kicked off. Consequently, the PR is added to merge queue, but the tests never run. This change removes the auto-merge setup, since it's not particularly taxing to click the green button.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/891)
<!-- Reviewable:end -->
