### PR TITLE
mysql: fixing GTIDs stored in the memo table.

### DIFF
--- a/internal/source/mylogical/conn.go
+++ b/internal/source/mylogical/conn.go
@@ -577,23 +577,24 @@ func (c *conn) persistWALOffset(ctx *stopper.Context) error {
 		if _, err := cp.parseFrom(string(found)); err != nil {
 			return err
 		}
-		c.walOffset.Set(cp)
+		log.Infof("Using GTID Set stored in the memo table: %s", cp)
 	} else if c.config.InitialGTID != "" {
 		// Set to a user-configured, default value.
 		cp, err = cp.parseFrom(c.config.InitialGTID)
 		if err != nil {
 			return err
 		}
+		log.Infof("Using GTID from the command line: %s", cp)
 	}
+	c.nextConsistentPoint = cp
 	c.walOffset.Set(cp)
-
 	ctx.Go(func(ctx *stopper.Context) error {
 		_, err := stopvar.DoWhenChanged(ctx, cp, &c.walOffset,
 			func(ctx *stopper.Context, _, cp *consistentPoint) error {
 				if err := c.memo.Put(ctx, c.stagingDB, key, []byte(cp.String())); err == nil {
 					log.Tracef("stored WAL offset %s: %s", key, cp)
 				} else {
-					log.WithError(err).Warn("could not persist WAL offset")
+					log.WithError(err).Error("could not persist WAL offset")
 				}
 				return nil
 			})

--- a/internal/source/mylogical/consistent_point_test.go
+++ b/internal/source/mylogical/consistent_point_test.go
@@ -21,13 +21,17 @@
 package mylogical
 
 import (
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func Test_mySqlStamp_Less(t *testing.T) {
+func TestMySqlStampLess(t *testing.T) {
 	tests := []struct {
 		name string
 		this string
@@ -71,7 +75,7 @@ func Test_mySqlStamp_Less(t *testing.T) {
 	}
 }
 
-func Test_mariadbStamp_Less(t *testing.T) {
+func TestMariadbStampLess(t *testing.T) {
 	tests := []struct {
 		name string
 		this string
@@ -106,6 +110,48 @@ func Test_mariadbStamp_Less(t *testing.T) {
 	}
 }
 
+type interval struct {
+	from int
+	to   int
+}
+
+func TestWithMysqlGTIDSet(t *testing.T) {
+
+	gtid := func(intervals []interval) string {
+		buff := strings.Builder{}
+
+		buff.WriteString("6fa7e6ef-c49a-11ec-950a-0242ac120002")
+		for _, interval := range intervals {
+			buff.WriteString(fmt.Sprintf(":%d-%d", interval.from, interval.to))
+		}
+		return buff.String()
+	}
+	tests := []struct {
+		name    string
+		initial string
+		add     string
+		want    string
+	}{
+		{"from empty", "", gtid([]interval{{1, 10}}), gtid([]interval{{1, 10}})},
+		{"noop", gtid([]interval{{1, 10}}), gtid([]interval{{1, 10}}), gtid([]interval{{1, 10}})},
+		{"contiguous", gtid([]interval{{1, 10}}), gtid([]interval{{11, 20}}), gtid([]interval{{1, 20}})},
+		{"disjoint", gtid([]interval{{1, 10}}), gtid([]interval{{12, 20}}), gtid([]interval{{1, 10}, {12, 20}})},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := require.New(t)
+			a := assert.New(t)
+			this, err := newConsistentPoint(mysql.MySQLFlavor).parseFrom(tt.initial)
+			r.NoError(err)
+			toAdd, err := mysql.ParseUUIDSet(tt.add)
+			r.NoError(err)
+			res := this.withMysqlGTIDSet(time.Now(), toAdd)
+
+			a.Equal(tt.want, res.my.Sets["6fa7e6ef-c49a-11ec-950a-0242ac120002"].String())
+		})
+	}
+
+}
 func checkMarshal(a *assert.Assertions, flavor string, cp *consistentPoint) {
 	data, err := cp.MarshalJSON()
 	if !a.NoError(err) {


### PR DESCRIPTION
Previously, the initial GTID set passed from the command line is not considered when computing the next consistent point. This cause the GTID set stored in the memo to miss the initial set.

This change ensures that we properly initialize the nextConsistentPoint on start up.

Fixes #892.