### PR TITLE
mysql: allowing target database name to be different from source database name.

### DIFF
--- a/internal/source/mylogical/conn.go
+++ b/internal/source/mylogical/conn.go
@@ -436,10 +436,8 @@ func (c *conn) getColNames(table ident.Table) ([][]byte, []uint64, error) {
 // Columns names are only available if
 // set global binlog_row_metadata = full;
 func (c *conn) onRelation(msg *replication.TableMapEvent) error {
-	tbl := ident.NewTable(
-		ident.MustSchema(ident.New(string(msg.Schema)), ident.Public),
-		ident.New(string(msg.Table)))
-	log.Tracef("Learned %+v", tbl)
+	targetTbl := ident.NewTable(c.target, ident.New(string(msg.Table)))
+	log.Tracef("Learned %+v", targetTbl)
 	columnNames, primaryKeys := msg.ColumnName, msg.PrimaryKey
 	// In case we need to fetch the metadata directly from the
 	// source, we will do it the first time we see the table,
@@ -448,13 +446,16 @@ func (c *conn) onRelation(msg *replication.TableMapEvent) error {
 		if _, ok := c.relations[msg.TableID]; ok {
 			return nil
 		}
+		sourceTbl := ident.NewTable(
+			ident.MustSchema(ident.New(string(msg.Schema)), ident.Public),
+			ident.New(string(msg.Table)))
 		var err error
-		columnNames, primaryKeys, err = c.getColNames(tbl)
+		columnNames, primaryKeys, err = c.getColNames(sourceTbl)
 		if err != nil {
 			return err
 		}
 	}
-	c.relations[msg.TableID] = tbl
+	c.relations[msg.TableID] = targetTbl
 	colData := make([]types.ColData, msg.ColumnCount)
 	primary := make(map[uint64]bool)
 	for _, p := range primaryKeys {
@@ -473,7 +474,7 @@ func (c *conn) onRelation(msg *replication.TableMapEvent) error {
 			Type:    fmt.Sprintf("%d", ctype),
 		}
 	}
-	c.columns.Put(tbl, colData)
+	c.columns.Put(targetTbl, colData)
 	return nil
 }
 

--- a/internal/source/mylogical/integration_test.go
+++ b/internal/source/mylogical/integration_test.go
@@ -78,16 +78,16 @@ func testMYLogical(t *testing.T, fc *fixtureConfig) {
 	fixture, err := all.NewFixture(t)
 	r.NoError(err)
 	ctx := fixture.Context
-	dbName := fixture.TargetSchema.Schema()
 	crdbPool := fixture.TargetPool
 
 	// Create the schema in both locations.
-	tgt := ident.NewTable(dbName, ident.New("t"))
+	tgt := ident.NewTable(fixture.TargetSchema.Schema(), ident.New("t"))
 
 	config, err := getConfig(fixture, fc, tgt)
 	r.NoError(err)
 
-	myPool, cancel, err := setupMYPool(config)
+	r.NotEqual(fixture.SourceSchema.Raw(), fixture.TargetSchema.Raw())
+	myPool, cancel, err := setupMYPool(config, fixture.SourceSchema.Idents(nil)[0])
 	r.NoError(err)
 	defer cancel()
 
@@ -225,11 +225,13 @@ func TestColumNames(t *testing.T) {
 	// Create a basic test fixture.
 	fixture, err := all.NewFixture(t)
 	r.NoError(err)
-	dbName := fixture.TargetSchema.Schema()
+	dbName := fixture.SourceSchema.Schema()
 	ctx := fixture.Context
 	config, err := getConfig(fixture, &fixtureConfig{}, ident.Table{})
 	r.NoError(err)
-	myPool, cancel, err := setupMYPool(config)
+
+	r.NotEqual(fixture.SourceSchema.Raw(), fixture.TargetSchema.Raw())
+	myPool, cancel, err := setupMYPool(config, fixture.SourceSchema.Idents(nil)[0])
 	r.NoError(err)
 	defer cancel()
 	flavor, _, err := getFlavor(config)
@@ -279,6 +281,7 @@ func TestColumNames(t *testing.T) {
 		})
 	}
 }
+
 func TestDataTypes(t *testing.T) {
 	a := assert.New(t)
 	r := require.New(t)
@@ -303,7 +306,8 @@ func TestDataTypes(t *testing.T) {
 	config, err := getConfig(fixture, &fixtureConfig{}, ident.Table{})
 	r.NoError(err)
 
-	myPool, cancel, err := setupMYPool(config)
+	r.NotEqual(fixture.SourceSchema.Raw(), fixture.TargetSchema.Raw())
+	myPool, cancel, err := setupMYPool(config, fixture.SourceSchema.Idents(nil)[0])
 	r.NoError(err)
 	defer cancel()
 
@@ -531,8 +535,9 @@ func myExec(
 		return conn.Execute(stmt, args...)
 	})
 }
-func setupMYPool(config *Config) (*client.Pool, func(), error) {
-	database := config.TargetSchema.Idents(nil)[0] // Extract database name.
+
+// setupMYPool establishes a connection to the source, creating the named database.
+func setupMYPool(config *Config, database ident.Ident) (*client.Pool, func(), error) {
 	addr := fmt.Sprintf("%s:%d", config.host, config.port)
 	var baseConn *client.Conn
 	var err error


### PR DESCRIPTION

Previously, running replicator for my logical with a target database name that was different from the source database name would fail.

This change allows target database name to be different for mylogical, similarly to the pglogical behavior.

Integration tests have been updated to verify the change.

Fixes #894.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/895)
<!-- Reviewable:end -->
