### PR TITLE
workflows: Initial release workflow

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,36 @@
+# Copyright 2024 The Cockroach Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+changelog:
+  categories:
+    - title: Breaking Changes
+      labels:
+        - R-breaking
+    - title: Enhancements
+      labels:
+        - R-enhancement
+    - title: Bug Fixes
+      labels:
+        - R-bugfix
+    - title: Dependency Updates
+      labels:
+        - dependencies
+    - title: Unclassified Changes
+      labels:
+        - "*"
+  exclude:
+    labels:
+      - R-exclude

--- a/.github/workflows/go-binaries.yaml
+++ b/.github/workflows/go-binaries.yaml
@@ -18,7 +18,7 @@
 # optionally push the results to a GCP bucket.
 name: Golang Binaries
 permissions:
-  contents: read
+  contents: write # Needed to modify release.
   id-token: write
   statuses: write
 on:
@@ -72,6 +72,11 @@ jobs:
           PACKAGE_GOARCH: ${{ matrix.arch }}
           UPLOAD_DIR: upload
         run: ./.github/workflows/package.sh
+
+      - id: release-artifacts
+        name: Attach binaries to GitHub Release
+        if: ${{ github.event.release.tag_name }}
+        run: gh release upload ${{ github.event.release.tag_name }} upload/*
 
       - id: auth
         name: Authenticate to GCP

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -32,7 +32,10 @@ on:
       - '.github/workflows/go*.yaml'
   push:
     branches: [ master ]
-    tags: [ 'v*.*.*' ]
+  release:
+    types:
+      - published
+
 jobs:
   # Most jobs should depend on this one.
   go-build-cache:
@@ -43,7 +46,7 @@ jobs:
     needs:
       - go-build-cache
     permissions:
-      contents: read
+      contents: write
       id-token: write
       statuses: write
     secrets: inherit


### PR DESCRIPTION
This change adds an automatic release notes configuration. PRs are categorized by `R-*` labels to populate the initial release notes.

The go build workflow will now trigger on a GitHub release being created, instead of on pushing a version tag. This will allow tarballs to be attached to the Release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/896)
<!-- Reviewable:end -->
