### PR TITLE
ndjson: moving ndjson parser to the util package so they can be reused.

### DIFF
--- a/internal/source/cdc/handler.go
+++ b/internal/source/cdc/handler.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cockroachdb/replicator/internal/conveyor"
 	"github.com/cockroachdb/replicator/internal/types"
+	"github.com/cockroachdb/replicator/internal/util/cdcjson"
 	"github.com/cockroachdb/replicator/internal/util/httpauth"
 	"github.com/cockroachdb/replicator/internal/util/ident"
 	"github.com/pkg/errors"
@@ -43,10 +44,11 @@ var sanitizer = strings.NewReplacer("\n", " ", "\r", " ")
 // Handler is an http.Handler for processing webhook requests
 // from a CockroachDB changefeed.
 type Handler struct {
-	Authenticator types.Authenticator // Access checks.
-	Config        *Config             // Runtime options.
-	Conveyors     *conveyor.Conveyors // Mutation delivery to the target.
-	TargetPool    *types.TargetPool   // Access to the target cluster.
+	Authenticator types.Authenticator   // Access checks.
+	Config        *Config               // Runtime options.
+	Conveyors     *conveyor.Conveyors   // Mutation delivery to the target.
+	NDJsonParser  *cdcjson.NDJsonParser // Parser for ndjson payloads.
+	TargetPool    *types.TargetPool     // Access to the target cluster.
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/internal/source/cdc/handler_test.go
+++ b/internal/source/cdc/handler_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/replicator/internal/types"
 	"github.com/cockroachdb/replicator/internal/util/applycfg"
 	"github.com/cockroachdb/replicator/internal/util/auth/reject"
+	"github.com/cockroachdb/replicator/internal/util/cdcjson"
 	"github.com/cockroachdb/replicator/internal/util/hlc"
 	"github.com/cockroachdb/replicator/internal/util/ident"
 	"github.com/cockroachdb/replicator/internal/util/merge"
@@ -158,13 +159,16 @@ func testQueryHandler(t *testing.T, htc *fixtureConfig) {
 		// Stage two lines of data. When this test is run with scripting
 		// enabled, we also want to see the bigint value successfully
 		// transit the JS runtime without being mangled.
-		a.NoError(h.ndjson(ctx, &request{
+		upsertRequest := &request{
 			target: tableInfo.Name(),
 			body: strings.NewReader(`
 {"after" : {"pk" : 42, "v" : 9007199254740995}, "updated": "1.0"}
 {"after":  {"pk" : 99, "v" : 42}, "updated": "1.0", "before": {"pk" : 99, "v" : 33 }}
 `),
-		}, h.parseNdjsonQueryMutation))
+		}
+		keys, err := h.getPrimaryKey(upsertRequest)
+		a.NoError(err)
+		a.NoError(h.ndjson(ctx, upsertRequest, cdcjson.QueryMutationReader(keys)))
 
 		// Verify staged data, if applicable.
 		if !htc.immediate {
@@ -200,16 +204,16 @@ func testQueryHandler(t *testing.T, htc *fixtureConfig) {
 		ct, err := tableInfo.RowCount(ctx)
 		a.NoError(err)
 		a.Equal(2, ct)
-
 		// Now, delete the data.
-		a.NoError(h.ndjson(ctx, &request{
+		deleteReq := &request{
 			target: tableInfo.Name(),
 			body: strings.NewReader(`
 {"before":{"pk" : 42, "v" : null},"updated": "3.0"}
 {"before":{"pk" : 99, "v" : null},"updated": "3.0"}
-`),
-		}, h.parseNdjsonQueryMutation))
-
+`)}
+		keys, err = h.getPrimaryKey(deleteReq)
+		a.NoError(err)
+		a.NoError(h.ndjson(ctx, deleteReq, cdcjson.QueryMutationReader(keys)))
 		a.NoError(h.resolved(ctx, &request{
 			target:    tableInfo.Name(),
 			timestamp: hlc.New(5, 0),
@@ -295,10 +299,14 @@ func testQueryHandler(t *testing.T, htc *fixtureConfig) {
 	// Verify that an empty post doesn't crash.
 	t.Run("empty-ndjson", func(t *testing.T) {
 		a := assert.New(t)
-		a.NoError(h.ndjson(ctx, &request{
+		emptyRequest := &request{
 			target: tableInfo.Name(),
 			body:   strings.NewReader(""),
-		}, h.parseNdjsonQueryMutation))
+		}
+
+		keys, err := h.getPrimaryKey(emptyRequest)
+		a.NoError(err)
+		a.NoError(h.ndjson(ctx, emptyRequest, cdcjson.QueryMutationReader(keys)))
 	})
 
 	// Verify that an empty webhook post doesn't crash.
@@ -362,7 +370,7 @@ func testHandler(t *testing.T, cfg *fixtureConfig) {
 { "after" : { "pk" : 42, "v" : 99 }, "key" : [ 42 ], "updated" : "1.0" }
 { "after" : { "pk" : 99, "v" : 42 }, "before": { "pk" : 99, "v" : 33 }, "key" : [ 99 ], "updated" : "1.0" }
 `),
-		}, parseNdjsonMutation))
+		}, cdcjson.BulkMutationReader()))
 
 		// Verify staged data, if applicable.
 		if !cfg.immediate {
@@ -406,7 +414,7 @@ func testHandler(t *testing.T, cfg *fixtureConfig) {
 { "after" : null, "key" : [ 42 ], "updated" : "3.0" }
 { "key" : [ 99 ], "updated" : "3.0" }
 `),
-		}, parseNdjsonMutation))
+		}, cdcjson.BulkMutationReader()))
 
 		a.NoError(h.resolved(ctx, &request{
 			target:    jumbleName(),
@@ -496,7 +504,7 @@ func testHandler(t *testing.T, cfg *fixtureConfig) {
 		a.NoError(h.ndjson(ctx, &request{
 			target: jumbleName(),
 			body:   strings.NewReader(""),
-		}, parseNdjsonMutation))
+		}, cdcjson.BulkMutationReader()))
 	})
 
 	// Verify that an empty webhook post doesn't crash.
@@ -558,7 +566,7 @@ v INT8 NOT NULL)`)
 				version,
 				v,
 			)),
-		}, parseNdjsonMutation)
+		}, cdcjson.BulkMutationReader())
 	}
 
 	// Send an update at V9. We're starting with 9 to ensure that when
@@ -624,7 +632,7 @@ v INT8 NOT NULL)`)
 				ts.Format(time.RFC3339Nano),
 				v,
 			)),
-		}, parseNdjsonMutation)
+		}, cdcjson.BulkMutationReader())
 	}
 
 	// Round time to reflect actual storage.

--- a/internal/source/cdc/ndjson.go
+++ b/internal/source/cdc/ndjson.go
@@ -19,90 +19,24 @@ package cdc
 // This file contains code repackaged from url.go.
 
 import (
-	"bufio"
-	"bytes"
 	"context"
-	"encoding/json"
 
 	"github.com/cockroachdb/replicator/internal/types"
-	"github.com/cockroachdb/replicator/internal/util/hlc"
+	"github.com/cockroachdb/replicator/internal/util/cdcjson"
 	"github.com/cockroachdb/replicator/internal/util/ident"
-	"github.com/pkg/errors"
 )
 
-// parseMutation takes a single line from an ndjson and extracts enough
-// information to be able to persist it to the staging table.
-type parseMutation func(*request, []byte) (types.Mutation, error)
-
-// parseNdjsonMutation is a parseMutation function
-func parseNdjsonMutation(_ *request, rawBytes []byte) (types.Mutation, error) {
-	var payload struct {
-		After   json.RawMessage `json:"after"`
-		Before  json.RawMessage `json:"before"`
-		Key     json.RawMessage `json:"key"`
-		Updated string          `json:"updated"`
-	}
-	// Large numbers are not turned into strings, so the UseNumber option for
-	// the decoder is required.
-	dec := json.NewDecoder(bytes.NewReader(rawBytes))
-	dec.UseNumber()
-	if err := dec.Decode(&payload); err != nil {
-		return types.Mutation{}, err
-	}
-	if payload.Updated == "" {
-		return types.Mutation{},
-			errors.New("CREATE CHANGEFEED must specify the 'WITH updated' option")
-	}
-
-	// Parse the timestamp into nanos and logical.
-	ts, err := hlc.Parse(payload.Updated)
-	if err != nil {
-		return types.Mutation{}, err
-	}
-	return types.Mutation{
-		Before: payload.Before,
-		Data:   payload.After,
-		Time:   ts,
-		Key:    payload.Key,
-	}, nil
-}
-
-// ndjson parses an incoming block of ndjson files and stores the
-// associated Mutations. This assumes that the underlying
-// Stager will store duplicate values in an idempotent manner,
-// should the request fail partway through.
-func (h *Handler) ndjson(ctx context.Context, req *request, parser parseMutation) error {
+func (h *Handler) ndjson(
+	ctx context.Context, req *request, mutParser cdcjson.MutationReader,
+) error {
 	table := req.target.(ident.Table)
-	batch := &types.MultiBatch{}
-
-	scanner := bufio.NewScanner(req.body)
-	// Our config defaults to bufio.MaxScanTokenSize.
-	scanner.Buffer(make([]byte, 0, h.Config.NDJsonBuffer), h.Config.NDJsonBuffer)
-	for scanner.Scan() {
-		buf := scanner.Bytes()
-		if len(buf) == 0 {
-			continue
-		}
-		mut, err := parser(req, buf)
-		if err != nil {
-			return err
-		}
-		// Discard phantom deletes.
-		if mut.IsDelete() && mut.Key == nil {
-			continue
-		}
-		if err := batch.Accumulate(table, mut); err != nil {
-			return err
-		}
-	}
-	if err := scanner.Err(); err != nil {
+	batch, err := h.NDJsonParser.Parse(table, mutParser, req.body)
+	if err != nil {
 		return err
 	}
-
 	conveyor, err := h.Conveyors.Get(table.Schema())
 	if err != nil {
 		return err
 	}
-
 	return conveyor.AcceptMultiBatch(ctx, batch, &types.AcceptOptions{})
 }

--- a/internal/source/cdc/primary_key.go
+++ b/internal/source/cdc/primary_key.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Cockroach Authors
+// Copyright 2024 The Cockroach Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,32 +16,10 @@
 
 package cdc
 
-// This file contains code repackaged from url.go.
-
 import (
-	"encoding/json"
-
-	"github.com/cockroachdb/replicator/internal/types"
 	"github.com/cockroachdb/replicator/internal/util/ident"
 	"github.com/pkg/errors"
 )
-
-// parseNdjsonQueryMutation is a parseMutation function.
-// We expect the CREATE CHANGE FEED INTO ... AS ... to use the following options:
-// envelope="wrapped",format="json",diff
-func (h *Handler) parseNdjsonQueryMutation(req *request, rawBytes []byte) (types.Mutation, error) {
-	keys, err := h.getPrimaryKey(req)
-	if err != nil {
-		return types.Mutation{}, err
-	}
-	qp := queryPayload{
-		keys: keys,
-	}
-	if err := json.Unmarshal(rawBytes, &qp); err != nil {
-		return types.Mutation{}, err
-	}
-	return qp.AsMutation()
-}
 
 // getPrimaryKey returns a map that contains all the columns that make up the primary key
 // for the target table and their ordinal position within the key.

--- a/internal/source/cdc/provider.go
+++ b/internal/source/cdc/provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/replicator/internal/sequencer"
 	"github.com/cockroachdb/replicator/internal/target/dlq"
 	"github.com/cockroachdb/replicator/internal/types"
+	"github.com/cockroachdb/replicator/internal/util/cdcjson"
 	"github.com/google/wire"
 )
 
@@ -63,10 +64,15 @@ func ProvideHandler(
 	if err := conveyors.Bootstrap(); err != nil {
 		return nil, err
 	}
+	parser, err := cdcjson.New(cfg.NDJsonBuffer)
+	if err != nil {
+		return nil, err
+	}
 	return &Handler{
 		Authenticator: auth,
 		Conveyors:     conveyors,
 		Config:        cfg,
+		NDJsonParser:  parser,
 		TargetPool:    pool,
 	}, nil
 }

--- a/internal/source/cdc/url_test.go
+++ b/internal/source/cdc/url_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/replicator/internal/types"
+	"github.com/cockroachdb/replicator/internal/util/cdcjson"
 	"github.com/cockroachdb/replicator/internal/util/hlc"
 	"github.com/cockroachdb/replicator/internal/util/ident"
 	"github.com/stretchr/testify/assert"
@@ -39,7 +40,7 @@ func TestParseChangefeedURL(t *testing.T) {
 	tableName := nameParts[2].Raw()
 	ndjsonDate := `2020-04-02`
 	ndjsonTimestampWithExtras := `202004022058072107140000000000000-56087568dba1e6b8-1-72-00000000-REAL-42-1.ndjson`
-	ndjson := strings.Join([]string{ndjsonDate, ndjsonTimestampWithExtras}, "/")
+	ndjsonWithDate := strings.Join([]string{ndjsonDate, ndjsonTimestampWithExtras}, "/")
 	ndjsonFull := `2020-04-02/202004022058072107140000000000000-56087568dba1e6b8-1-72-00000000-ignored_db.ignored_schema.REAL-42-1.ndjson`
 	resolvedDate := `2020-04-04`
 	resolvedTimestamp := `202004042351304139680000000000000.RESOLVED`
@@ -139,7 +140,7 @@ func TestParseChangefeedURL(t *testing.T) {
 			name:     "ndjson to schema",
 			decision: "ndjson schema",
 			target:   ident.NewTable(schemaIdent, ident.New("REAL-42")), // Use topic name from query.
-			url:      strings.Join([]string{"", dbName, schemaName, ndjson}, "/"),
+			url:      strings.Join([]string{"", dbName, schemaName, ndjsonWithDate}, "/"),
 		},
 		{
 			name:     "ndjson full to schema",
@@ -151,24 +152,24 @@ func TestParseChangefeedURL(t *testing.T) {
 			name:     "table that looks like a malformed ndjson",
 			decision: "webhook table",
 			target:   ident.NewTable(ident.MustSchema(ident.New(dbName), ident.New(ndjsonDate)), ident.New(ndjsonTimestampWithExtras)),
-			url:      strings.Join([]string{"", dbName, ndjson}, "/"),
+			url:      strings.Join([]string{"", dbName, ndjsonWithDate}, "/"),
 		},
 		{
 			name:    "ndjson too long",
-			url:     strings.Join([]string{"", dbName, schemaName, "too", "much", ndjson}, "/"),
+			url:     strings.Join([]string{"", dbName, schemaName, "too", "much", ndjsonWithDate}, "/"),
 			wantErr: "path did not match any expected patterns",
 		},
 		{
 			name:     "ndjson to table",
 			decision: "ndjson table",
 			target:   tableIdent,
-			url:      strings.Join([]string{"", dbName, schemaName, tableName, ndjson}, "/"),
+			url:      strings.Join([]string{"", dbName, schemaName, tableName, ndjsonWithDate}, "/"),
 		},
 		{
 			name:     "ndjson to table extra slashes",
 			decision: "ndjson table",
 			target:   tableIdent,
-			url:      strings.Join([]string{"", dbName, schemaName, "", "", tableName, "", ndjson, ""}, "/"),
+			url:      strings.Join([]string{"", dbName, schemaName, "", "", tableName, "", ndjsonWithDate, ""}, "/"),
 		},
 		{
 			name:     "ndjson full to table",
@@ -178,7 +179,11 @@ func TestParseChangefeedURL(t *testing.T) {
 		},
 	}
 
+	r := require.New(t)
+	parser, err := cdcjson.New(1000)
+	r.NoError(err)
 	h := &Handler{
+		NDJsonParser: parser,
 		TargetPool: &types.TargetPool{
 			PoolInfo: types.PoolInfo{Product: types.ProductCockroachDB},
 		},

--- a/internal/util/cdcjson/ndjson_parser.go
+++ b/internal/util/cdcjson/ndjson_parser.go
@@ -1,0 +1,99 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package cdcjson provides utilities to decode json changefeeds.
+package cdcjson
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+
+	"github.com/cockroachdb/replicator/internal/types"
+	"github.com/cockroachdb/replicator/internal/util/hlc"
+	"github.com/cockroachdb/replicator/internal/util/ident"
+	"github.com/pkg/errors"
+)
+
+// NDJsonParser provides the functionality to process changefeed events encoded
+// as ndjson.
+type NDJsonParser struct {
+	bufferSize int
+}
+
+// New builds a parser with the given buffer size.
+func New(bufferSize int) (*NDJsonParser, error) {
+	if bufferSize <= 0 {
+		return nil, errors.Errorf("invalid buffer size %d; it must be a positive integer", bufferSize)
+	}
+	return &NDJsonParser{
+		bufferSize: bufferSize,
+	}, nil
+}
+
+// Parse reads a stream of mutations. Each mutation is extracted by
+// calling the provided MutationParser function.
+func (n *NDJsonParser) Parse(
+	table ident.Table, parseMutation MutationReader, reader io.Reader,
+) (*types.MultiBatch, error) {
+	batch := &types.MultiBatch{}
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, n.bufferSize), n.bufferSize)
+	for scanner.Scan() {
+		buf := scanner.Bytes()
+		if len(buf) == 0 {
+			continue
+		}
+		mut, err := parseMutation(bytes.NewBuffer(buf))
+		if err != nil {
+			return nil, err
+		}
+		// Discard phantom deletes.
+		if mut.IsDelete() && mut.Key == nil {
+			continue
+		}
+		if err := batch.Accumulate(table, mut); err != nil {
+			return nil, err
+		}
+	}
+	return batch, scanner.Err()
+}
+
+// Resolved extracts the resolved timestamp
+func (n *NDJsonParser) Resolved(reader io.Reader) (hlc.Time, error) {
+	var payload struct {
+		Resolved string `json:"resolved"`
+	}
+	if err := Decode(reader, &payload); err != nil {
+		return hlc.Zero(), err
+	}
+	if payload.Resolved == "" {
+		return hlc.Zero(),
+			errors.New("CREATE CHANGEFEED must specify the 'WITH resolved' option")
+	}
+	// Parse the timestamp into nanos and logical.
+	return hlc.Parse(payload.Resolved)
+}
+
+// Decode a JSON object.
+func Decode(r io.Reader, v any) error {
+	// Large numbers are not turned into strings, so the UseNumber option for
+	// the decoder is required.
+	dec := json.NewDecoder(r)
+	dec.UseNumber()
+	return dec.Decode(v)
+}

--- a/internal/util/cdcjson/ndjson_parser_test.go
+++ b/internal/util/cdcjson/ndjson_parser_test.go
@@ -1,0 +1,110 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cdcjson
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/replicator/internal/util/hlc"
+	"github.com/cockroachdb/replicator/internal/util/ident"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name    string
+		request string
+		want    int
+		wantErr string
+	}{
+		{
+			name:    "one",
+			request: `{"after" : {"pk" : 42, "v" : 9007199254740995}, "key": [42], "updated": "1.0"}`,
+			want:    1,
+		},
+		{
+			name: "two",
+			request: `{"before" : {"pk" : 42, "v" : 9007199254740995}, "key": [42],"updated": "2.0"}
+{"after" : {"pk" : 42, "v" : 9007199254740995}, "key": [42], "updated": "1.0"}`,
+			want: 2,
+		},
+		{
+			name: "delete no key",
+			request: `{"before" : {"pk" : 42, "v" : 9007199254740995},"updated": "2.0"}
+{"after" : {"pk" : 42, "v" : 9007199254740995}, "key": [42], "updated": "1.0"}`,
+			want: 1,
+		},
+	}
+	r := require.New(t)
+	parser, err := New(1000)
+	r.NoError(err)
+	table := ident.NewTable(ident.MustSchema(ident.Public), ident.New("table"))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+			got, err := parser.Parse(table, BulkMutationReader(), strings.NewReader(tt.request))
+			if tt.wantErr != "" {
+				a.ErrorContains(err, tt.wantErr)
+				return
+			}
+			a.NoError(err)
+			a.Equal(tt.want, got.Count())
+		})
+	}
+}
+
+func TestResolved(t *testing.T) {
+	tests := []struct {
+		name    string
+		request string
+		want    hlc.Time
+		wantErr string
+	}{
+		{
+			name:    "ok",
+			request: `{"resolved": "1716390502992757000.0000000000"}`,
+			want:    hlc.New(1716390502992757000, 0),
+		},
+		{
+			name:    "no timestamp",
+			request: `{"something": "1716390502992757000.0000000000"}`,
+			wantErr: "CREATE CHANGEFEED must specify the 'WITH resolved' option",
+		},
+		{
+			name:    "invalid timestamp",
+			request: `{"resolved": "not a timestamp" }`,
+			wantErr: "can't parse timestamp",
+		},
+	}
+	r := require.New(t)
+	parser, err := New(1000)
+	r.NoError(err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+			got, err := parser.Resolved(strings.NewReader(tt.request))
+			if tt.wantErr != "" {
+				a.ErrorContains(err, tt.wantErr)
+				return
+			}
+			a.NoError(err)
+			a.Equal(tt.want, got)
+		})
+	}
+}

--- a/internal/util/cdcjson/query_payload.go
+++ b/internal/util/cdcjson/query_payload.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Cockroach Authors
+// Copyright 2024 The Cockroach Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package cdc
+package cdcjson
 
 import (
 	"encoding/json"
@@ -33,7 +33,10 @@ var (
 	updated     = ident.New("updated")
 )
 
-const bareEnvelopeErrorMsg = `bare envelope is not supported. Use envelope="wrapped",format="json",diff in CREATE CHANGEFEED ... AS SELECT`
+// Errors
+var (
+	ErrBareEnvelope = errors.New(`bare envelope is not supported. Use envelope="wrapped",format="json",diff in CREATE CHANGEFEED ... AS SELECT`)
+)
 
 // queryPayload stores the payload sent by the client for
 // a change feed that uses a query
@@ -89,7 +92,7 @@ func (q *queryPayload) UnmarshalJSON(data []byte) error {
 	}
 	// Check if it is a bare message. Bare messages have a `__crdb__` property.
 	if _, hasCrdb := msg.Get(crdbLabel); hasCrdb {
-		return errors.New(bareEnvelopeErrorMsg)
+		return ErrBareEnvelope
 	}
 	ts, ok := msg.Get(updated)
 	if !ok {

--- a/internal/util/cdcjson/query_payload_test.go
+++ b/internal/util/cdcjson/query_payload_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Cockroach Authors
+// Copyright 2024 The Cockroach Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package cdc
+package cdcjson
 
 import (
 	"encoding/json"
@@ -50,7 +50,7 @@ func TestQueryPayload(t *testing.T) {
 			`{"__event__": "insert", "pk" : 42, "v" : 9, "__crdb__": {"updated": "1.0"}}`,
 			ident.MapOf[int](ident.New("pk"), 0),
 			types.Mutation{},
-			bareEnvelopeErrorMsg,
+			ErrBareEnvelope.Error(),
 		},
 		{"update with diff",
 			`{"after":{"pk":42,"v":9},"before":{"pk":42,"v":10},"updated":"1.0"}`,

--- a/internal/util/cdcjson/reader.go
+++ b/internal/util/cdcjson/reader.go
@@ -1,0 +1,76 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cdcjson
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/cockroachdb/replicator/internal/types"
+	"github.com/cockroachdb/replicator/internal/util/hlc"
+	"github.com/cockroachdb/replicator/internal/util/ident"
+	"github.com/pkg/errors"
+)
+
+// MutationReader is the function that extracts a mutation from a from a
+// Reader whose contents are a single line of the input.
+type MutationReader func(io.Reader) (types.Mutation, error)
+
+// BulkMutationReader returns a function that reads a mutation from a
+// regular changefeed.
+func BulkMutationReader() MutationReader {
+	return func(reader io.Reader) (types.Mutation, error) {
+		var payload struct {
+			After   json.RawMessage `json:"after"`
+			Before  json.RawMessage `json:"before"`
+			Key     json.RawMessage `json:"key"`
+			Updated string          `json:"updated"`
+		}
+		if err := Decode(reader, &payload); err != nil {
+			return types.Mutation{}, err
+		}
+		if payload.Updated == "" {
+			return types.Mutation{},
+				errors.New("CREATE CHANGEFEED must specify the 'WITH updated' option")
+		}
+
+		// Parse the timestamp into nanos and logical.
+		ts, err := hlc.Parse(payload.Updated)
+		if err != nil {
+			return types.Mutation{}, err
+		}
+		return types.Mutation{
+			Before: payload.Before,
+			Data:   payload.After,
+			Time:   ts,
+			Key:    payload.Key,
+		}, nil
+	}
+}
+
+// QueryMutationReader reads a mutation from a query changefeed.
+func QueryMutationReader(keys *ident.Map[int]) MutationReader {
+	return func(reader io.Reader) (types.Mutation, error) {
+		payload := queryPayload{
+			keys: keys,
+		}
+		if err := Decode(reader, &payload); err != nil {
+			return types.Mutation{}, err
+		}
+		return payload.AsMutation()
+	}
+}

--- a/internal/util/cdcjson/reader_test.go
+++ b/internal/util/cdcjson/reader_test.go
@@ -1,0 +1,76 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cdcjson
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/replicator/internal/types"
+	"github.com/cockroachdb/replicator/internal/util/hlc"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBulkMutationReader(t *testing.T) {
+	tests := []struct {
+		name    string
+		request string
+		want    types.Mutation
+		wantErr string
+	}{
+		{
+			name:    "upsert",
+			request: `{"after" : {"pk" : 42, "v" : 9007199254740995}, "key": [42], "updated": "1.0"}`,
+			want: types.Mutation{
+				Data: []byte(`{"pk" : 42, "v" : 9007199254740995}`),
+				Key:  []byte(`[42]`),
+				Time: hlc.New(1, 0),
+			},
+		},
+		{
+			name:    "delete",
+			request: `{"before" : {"pk" : 42, "v" : 9007199254740995}, "key": [42] , "updated": "2.0"}`,
+			want: types.Mutation{
+				Before: []byte(`{"pk" : 42, "v" : 9007199254740995}`),
+				Key:    []byte(`[42]`),
+				Time:   hlc.New(2, 0),
+			},
+		},
+		{
+			name:    "no timestamp",
+			request: `{"before" : {"pk" : 42, "v" : 9007199254740995}, "key": [42]}`,
+			wantErr: "CREATE CHANGEFEED must specify the 'WITH updated' option",
+		},
+		{
+			name:    "invalid timestamp",
+			request: `{"before" : {"pk" : 42, "v" : 9007199254740995}, "key": [42], "updated": "not a timestamp" }`,
+			wantErr: "can't parse timestamp",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+			got, err := BulkMutationReader()(strings.NewReader(tt.request))
+			if tt.wantErr != "" {
+				a.ErrorContains(err, tt.wantErr)
+				return
+			}
+			a.NoError(err)
+			a.Equal(tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
The functionality within the cdc that is used to process json can be reused by other source (namely, cloud storage connectors).
    
This change moves such functionality under the util packages.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/900)
<!-- Reviewable:end -->
