### PR TITLE
seqtest: Make CheckSequencer work with Immediate

### DIFF
--- a/internal/cmd/workload/workload_test.go
+++ b/internal/cmd/workload/workload_test.go
@@ -62,7 +62,7 @@ func TestWorkload(t *testing.T) {
 		},
 	}
 
-	workload, group, err := fixture.NewWorkload(ctx)
+	workload, group, err := fixture.NewWorkload(ctx, &all.WorkloadConfig{})
 	r.NoError(err)
 
 	cfg := &clientConfig{

--- a/internal/sequencer/besteffort/besteffort_test.go
+++ b/internal/sequencer/besteffort/besteffort_test.go
@@ -250,7 +250,7 @@ CONSTRAINT parent_fk FOREIGN KEY(parent) REFERENCES %s(parent)
 }
 
 func TestBestEffort(t *testing.T) {
-	seqtest.CheckSequencer(t,
+	seqtest.CheckSequencer(t, &all.WorkloadConfig{},
 		func(t *testing.T, fixture *all.Fixture, seqFixture *seqtest.Fixture) sequencer.Sequencer {
 			// We only want BestEffort to do work when told; the test
 			// rig uses a counter to generate timestamps.

--- a/internal/sequencer/core/core_test.go
+++ b/internal/sequencer/core/core_test.go
@@ -136,7 +136,7 @@ val INT DEFAULT 0 NOT NULL
 }
 
 func TestSerial(t *testing.T) {
-	seqtest.CheckSequencer(t,
+	seqtest.CheckSequencer(t, &all.WorkloadConfig{},
 		func(t *testing.T, fixture *all.Fixture, seqFixture *seqtest.Fixture) sequencer.Sequencer {
 			return seqFixture.Core
 		},

--- a/internal/sequencer/immediate/immediate_test.go
+++ b/internal/sequencer/immediate/immediate_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 // This can be seen as a skeleton for more interesting sequencers.
-func TestImmediate(t *testing.T) {
+func TestStepByStep(t *testing.T) {
 	r := require.New(t)
 	fixture, err := all.NewFixture(t)
 	r.NoError(err)
@@ -94,4 +94,16 @@ func TestImmediate(t *testing.T) {
 			r.Fail("timed out")
 		}
 	}
+}
+
+func TestImmediate(t *testing.T) {
+	seqtest.CheckSequencer(t,
+		&all.WorkloadConfig{
+			DisableFK:         true,
+			DisablePreStaging: true,
+		},
+		func(t *testing.T, fixture *all.Fixture, seqFixture *seqtest.Fixture) sequencer.Sequencer {
+			return seqFixture.Immediate
+		},
+		func(t *testing.T, check *seqtest.Check) {})
 }

--- a/internal/sequencer/seqtest/check.go
+++ b/internal/sequencer/seqtest/check.go
@@ -74,11 +74,16 @@ func (f CheckFlag) String() string {
 // support foreign-key relationships. The post-hook may be nil.
 func CheckSequencer(
 	t *testing.T,
+	workloadCfg *all.WorkloadConfig,
 	pre func(t *testing.T, fixture *all.Fixture, seqFixture *Fixture) sequencer.Sequencer,
 	post func(t *testing.T, check *Check),
 ) {
 	const batches = 1_000
 	check := func(t *testing.T, flags CheckFlag) {
+		if workloadCfg.DisablePreStaging && flags&checkStage == checkStage {
+			t.Log("staging disabled by WorkloadConfig")
+			return
+		}
 		r := require.New(t)
 
 		fixture, err := all.NewFixture(t)
@@ -110,7 +115,7 @@ func CheckSequencer(
 			Sequencer: seq,
 			Stage:     flags&checkStage == checkStage,
 		}
-		basic.Check(ctx, t)
+		basic.Check(ctx, t, workloadCfg)
 		if post != nil {
 			post(t, basic)
 		}
@@ -145,10 +150,10 @@ type Check struct {
 }
 
 // Check generates data and verifies that it reaches the target tables.
-func (c *Check) Check(ctx *stopper.Context, t testing.TB) {
+func (c *Check) Check(ctx *stopper.Context, t testing.TB, cfg *all.WorkloadConfig) {
 	r := require.New(t)
 
-	generator, group, err := c.Fixture.NewWorkload(ctx)
+	generator, group, err := c.Fixture.NewWorkload(ctx, cfg)
 	r.NoError(err)
 	c.Group = group
 
@@ -179,9 +184,11 @@ func (c *Check) Check(ctx *stopper.Context, t testing.TB) {
 			}))
 		}
 	} else {
-		// We're going to fragment the batch to simulate data being received
-		// piecemeal by multiple instances of Replicator. We ensure that the child
-		// fragments must be processed before the parent fragments.
+		// We're going to fragment the batch to simulate data being
+		// received piecemeal by multiple instances of Replicator. We
+		// ensure that the child fragments must be processed before the
+		// parent fragments to ensure FK relationships are correctly
+		// implemented.
 		fragments, err := Fragment(testData)
 		r.NoError(err)
 		r.Len(fragments, 2)

--- a/internal/sequencer/switcher/switcher_test.go
+++ b/internal/sequencer/switcher/switcher_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TestSwitcher(t *testing.T) {
-	seqtest.CheckSequencer(t,
+	seqtest.CheckSequencer(t, &all.WorkloadConfig{},
 		func(t *testing.T, fixture *all.Fixture, seqFixture *seqtest.Fixture) sequencer.Sequencer {
 			ctx := fixture.Context
 			// Ensure we cove both startup cases in CI.

--- a/internal/sinktest/all/workload.go
+++ b/internal/sinktest/all/workload.go
@@ -40,9 +40,18 @@ type Workload struct {
 	fixture *Fixture
 }
 
+// WorkloadConfig provides additional parameters to
+// [Fixture.NewWorkload].
+type WorkloadConfig struct {
+	DisableFK         bool // Don't create FK references from child to parent.
+	DisablePreStaging bool // Don't test resuming by pre-populating staging tables.
+}
+
 // NewWorkload constructs a parent/child workload test rig attached to
 // the test fixture.
-func (f *Fixture) NewWorkload(ctx context.Context) (*Workload, *types.TableGroup, error) {
+func (f *Fixture) NewWorkload(
+	ctx context.Context, cfg *WorkloadConfig,
+) (*Workload, *types.TableGroup, error) {
 	// We want at least a 64-bit value.
 	bigType := "BIGINT"
 	if f.TargetPool.Product == types.ProductOracle {
@@ -56,13 +65,24 @@ func (f *Fixture) NewWorkload(ctx context.Context) (*Workload, *types.TableGroup
 		return nil, nil, err
 	}
 
-	childInfo, err := f.CreateTargetTable(ctx, fmt.Sprintf(
+	// The child table may be generated with or without an FK reference.
+	childSchema := fmt.Sprintf(
 		`CREATE TABLE %%s (
 child %[2]s PRIMARY KEY,
 parent %[2]s NOT NULL,
 val %[2]s DEFAULT 0 NOT NULL,
 CONSTRAINT parent_fk FOREIGN KEY(parent) REFERENCES %[1]s(parent)
-)`, parentInfo.Name(), bigType))
+)`, parentInfo.Name(), bigType)
+	if cfg.DisableFK {
+		childSchema = fmt.Sprintf(
+			`CREATE TABLE %%s (
+child %[1]s PRIMARY KEY,
+parent %[1]s NOT NULL,
+val %[1]s DEFAULT 0 NOT NULL
+)`, bigType)
+	}
+
+	childInfo, err := f.CreateTargetTable(ctx, childSchema)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/source/cdc/handler_test.go
+++ b/internal/source/cdc/handler_test.go
@@ -696,7 +696,7 @@ func TestSyntheticWebhooks(t *testing.T) {
 	fixture, _ := createFixture(t, &fixtureConfig{})
 	ctx := fixture.Context
 
-	gen, _, err := fixture.NewWorkload(ctx)
+	gen, _, err := fixture.NewWorkload(ctx, &all.WorkloadConfig{})
 	r.NoError(err)
 
 	batch := &types.MultiBatch{}


### PR DESCRIPTION
This change adds some extra configuration plumbing so that the Immedate sequencer can be tested and verified with approximately the same tests used on other sequencers. The points of configuration are to disable foreign keys in the target schema and to skip any tests which would pre-populate staging tables.

X-Ref: #898

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/901)
<!-- Reviewable:end -->
