### PR TITLE
objstore: adding ErrTransient and ErrSkipAll error markers.

### DIFF
--- a/internal/source/objstore/bucket/errors.go
+++ b/internal/source/objstore/bucket/errors.go
@@ -24,4 +24,8 @@ var (
 	ErrNoSuchBucket = errors.New("bucket not found")
 	// ErrNoSuchKey must be returned if there is no object with the given key.
 	ErrNoSuchKey = errors.New("key not found")
+	// ErrTransient represent an error that can be retried.
+	ErrTransient = errors.New("the operation causing the error may be retried")
+	// ErrSkipAll signal that Walk can stop process the follow entries.
+	ErrSkipAll = errors.New("skip the rest of objects")
 )

--- a/internal/source/objstore/providers/local/local.go
+++ b/internal/source/objstore/providers/local/local.go
@@ -57,7 +57,7 @@ func (b *localBucket) Walk(
 ) error {
 	count := 0
 	dir = filepath.Clean(dir)
-	return fs.WalkDir(b.filesystem, dir,
+	err := fs.WalkDir(b.filesystem, dir,
 		func(path string, d fs.DirEntry, err error) error {
 			if options.StartAfter != "" && strings.Compare(path, options.StartAfter) <= 0 {
 				return nil
@@ -74,6 +74,10 @@ func (b *localBucket) Walk(
 			count++
 			return f(ctx, path)
 		})
+	if errors.Is(err, bucket.ErrSkipAll) {
+		return nil
+	}
+	return err
 }
 
 // Open implements bucket.Reader

--- a/internal/source/objstore/providers/local/local_test.go
+++ b/internal/source/objstore/providers/local/local_test.go
@@ -61,6 +61,11 @@ func TestWalk(t *testing.T) {
 	suite(t).Walk(t)
 }
 
+// WalkWithSkipAll validates bucket.Reader.Walk with ErrSkipAll
+func TestWalkWithSkipAll(t *testing.T) {
+	suite(t).WalkWithSkipAll(t)
+}
+
 // suite builds a validator for a in memory filesystem.
 func suite(t *testing.T) *storetest.Suite {
 	rootFS := memfs.New()

--- a/internal/source/objstore/providers/s3/s3_test.go
+++ b/internal/source/objstore/providers/s3/s3_test.go
@@ -108,6 +108,10 @@ func TestWalk(t *testing.T) {
 	suite().Walk(t)
 }
 
+func TestWalkWithSkipAll(t *testing.T) {
+	suite().WalkWithSkipAll(t)
+}
+
 func suite() *storetest.Suite {
 	mockS3 := &mockS3{
 		bucketName: "test",


### PR DESCRIPTION
This change adds a ErrTransient error that providers may use to identify transient errors to signal to clients that operation may be retried.

This change also adds a ErrSkipAll error that client may use in the Walk function to indicate that all remaining entries should be skipped.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/903)
<!-- Reviewable:end -->
