### PR TITLE
kafka: deduping messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/google/go-licenses v1.6.0
 	github.com/google/uuid v1.6.0
 	github.com/google/wire v0.6.0
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jackc/pglogrepl v0.0.0-20240307033717-828fbfe908e9
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/joonix/log v0.0.0-20200409080653-9c1d2ceb5f1d

--- a/go.sum
+++ b/go.sum
@@ -300,6 +300,8 @@ github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/C
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20220319035150-800ac71e25c2/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=

--- a/internal/source/kafka/cache.go
+++ b/internal/source/kafka/cache.go
@@ -1,0 +1,182 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kafka
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/cockroachdb/field-eng-powertools/stopper"
+	"github.com/cockroachdb/replicator/internal/util/hlc"
+	lru "github.com/hashicorp/golang-lru/v2"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	disableCache = 0
+)
+
+// cache keeps track of the timestamps for each key on a partition basis.
+type cache struct {
+	impl      *lru.Cache[string, hlc.Time]
+	partition string
+	size      int
+	topic     string
+	mu        struct {
+		sync.RWMutex
+		high hlc.Time // high watermark: the most recent timestamp we encountered.
+		low  hlc.Time // low watermark corresponds to the latest resolved timestamp.
+	}
+}
+
+// newCache creates a LRU cache to track timestamps for each primary key
+// for the given topic and partition.
+func newCache(ctx *stopper.Context, topic string, partition, size int) (*cache, error) {
+	if size > disableCache {
+		impl, err := lru.New[string, hlc.Time](size)
+		if err != nil {
+			return nil, err
+		}
+		cache := &cache{
+			impl:      impl,
+			partition: strconv.Itoa(partition),
+			size:      size,
+			topic:     topic,
+		}
+		// TODO (Silvano):  Is this strictly necessary? Can we just have the cache
+		// clean up as needed. Maybe we can make it optional with a config flag.
+		cache.backgroundEvict(ctx)
+		return cache, nil
+	}
+	return nil, nil
+}
+
+// backgroundEvict periodically removes entries that are older than
+// the low watermark.
+func (c *cache) backgroundEvict(ctx *stopper.Context) {
+	if c == nil {
+		return
+	}
+	ticker := time.NewTicker(100 * time.Millisecond)
+	ctx.Go(func(ctx *stopper.Context) error {
+		for {
+			c.maybeEvict()
+			select {
+			case <-ctx.Stopping():
+				log.Infof("stopping cache eviction for %s.%s", c.topic, c.partition)
+				return nil
+			case <-ticker.C:
+			}
+		}
+	})
+}
+
+// getHigh return the high watermark timestamp
+func (c *cache) getHigh() hlc.Time {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.mu.high
+}
+
+// getHigh return the low watermark timestamp
+func (c *cache) getLow() hlc.Time {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.mu.low
+}
+
+// inNewer check if the timestamp for this message key is older than
+// the latest timestamp we received for the same key.
+// If it is newer it updates the entry in the cache.
+func (c *cache) inNewer(msg *sarama.ConsumerMessage, timestamp hlc.Time) bool {
+	if c == nil {
+		return true
+	}
+	if hlc.Compare(timestamp, c.getHigh()) > 0 {
+		c.setHigh(timestamp)
+	}
+	if hlc.Compare(timestamp, c.getLow()) < 0 {
+		// A message came after the resolved timestamp.
+		// This shouldn't happen, but we track it.
+		oldMessagesCount.WithLabelValues(c.topic, c.partition).Inc()
+		return false
+	}
+	key := fmt.Sprintf("%s-.-%d-.-%s", msg.Topic, msg.Partition, msg.Key)
+	if previous, ok := c.impl.Get(string(key)); ok && hlc.Compare(timestamp, previous) < 0 {
+		duplicateMessagesCount.WithLabelValues(c.topic, c.partition).Inc()
+		return false
+	}
+	c.impl.Add(string(key), timestamp)
+	return true
+}
+
+// markResolved indicates that any entries older that the given timestamp can be evicted.
+// if there are no entries that have a newer timestamp, the cache is purged.
+func (c *cache) markResolved(timestamp hlc.Time) {
+	if c == nil {
+		return
+	}
+	// if there is nothing newer we just wipe the cache.
+	if hlc.Compare(timestamp, c.getHigh()) > 0 {
+		start := time.Now()
+		c.impl.Purge()
+		dur := time.Since(start)
+		purgeDuration.WithLabelValues(c.topic, c.partition).Observe(float64(dur.Microseconds()))
+		c.setHigh(timestamp)
+	}
+	// Anything older that this timestamp can be cleaned.
+	c.setLow(timestamp)
+}
+
+// maybeEvict evicts the entries that have a timestamp value older that the low watermark.
+// It scans entries started from the oldest entry added to the cache. Given that the
+// timestamp (values) in the cache are not necessarily in the same order of when they are
+// added in the cache, the algorithm is best effort.
+func (c *cache) maybeEvict() {
+	count := 0
+	start := time.Now()
+	for {
+		cacheSize.WithLabelValues(c.topic, c.partition).Set(float64(c.impl.Len()))
+		if k, ts, ok := c.impl.GetOldest(); ok && hlc.Compare(ts, c.getLow()) < 0 {
+			count++
+			c.impl.Remove(k)
+			continue
+		}
+		if count > 0 {
+			dur := time.Since(start)
+			evictDuration.WithLabelValues(c.topic, c.partition).Observe(float64(dur.Microseconds()))
+		}
+		return
+	}
+}
+
+// setHigh updates the high watermark timestamp
+func (c *cache) setHigh(timestamp hlc.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.mu.high = timestamp
+}
+
+// setLow updates the low watermark timestamp
+func (c *cache) setLow(timestamp hlc.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.mu.low = timestamp
+}

--- a/internal/source/kafka/cache_test.go
+++ b/internal/source/kafka/cache_test.go
@@ -1,0 +1,101 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kafka
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/IBM/sarama"
+	"github.com/cockroachdb/replicator/internal/util/hlc"
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkEvict(b *testing.B) {
+	r := require.New(b)
+	impl, err := lru.New[string, hlc.Time](b.N * 2)
+	r.NoError(err)
+	cache := &cache{
+		impl: impl,
+	}
+	for i := 0; i < b.N; i++ {
+		cache.impl.Add(fmt.Sprintf("%d", i), hlc.New(int64(i), 0))
+	}
+	cache.setLow(hlc.New(int64(b.N), 0))
+	cache.maybeEvict()
+}
+
+func BenchmarkPurge(b *testing.B) {
+	r := require.New(b)
+	impl, err := lru.New[string, hlc.Time](b.N * 2)
+	r.NoError(err)
+	cache := &cache{
+		impl: impl,
+	}
+	for i := 0; i < b.N; i++ {
+		cache.impl.Add(fmt.Sprintf("%d", i), hlc.New(int64(i), 0))
+	}
+	cache.impl.Purge()
+}
+
+func TestCache(t *testing.T) {
+	num := 1000
+	r := require.New(t)
+	a := assert.New(t)
+	impl, err := lru.New[string, hlc.Time](num * 2)
+	r.NoError(err)
+	cache := &cache{
+		impl: impl,
+	}
+	// Adding (0,0) to (999,0) to the cache
+	for i := 0; i < num; i++ {
+		msg := &sarama.ConsumerMessage{
+			Key: []byte(fmt.Sprintf("%d", i)),
+		}
+		a.True(cache.inNewer(msg, hlc.New(int64(i), 0)))
+	}
+	// Adding (1000,0) to (1999,0) to the cache
+	for i := 0; i < num; i++ {
+		msg := &sarama.ConsumerMessage{
+			Key: []byte(fmt.Sprintf("%d", i)),
+		}
+		a.True(cache.inNewer(msg, hlc.New(int64(num+i), 0)))
+	}
+	// Replaying (0,0) to (999,0) to the cache
+	for i := 0; i < num; i++ {
+		msg := &sarama.ConsumerMessage{
+			Key: []byte(fmt.Sprintf("%d", i)),
+		}
+		a.False(cache.inNewer(msg, hlc.New(int64(i), 0)))
+	}
+	// Mark resolved everything older than  (1500,0)
+	cache.markResolved(hlc.New(int64(num+num/2), 0))
+	// Evict older entries
+	cache.maybeEvict()
+	// We should have everything after and including (1500,0)
+	a.Equal(500, cache.impl.Len())
+	for _, timestamp := range cache.impl.Values() {
+		compare := func() bool { return hlc.Compare(timestamp, hlc.New(int64(num+num/2), 0)) >= 0 }
+		a.Condition(compare)
+	}
+	// Mark resolved everything older than  (2001,0)
+	cache.markResolved(hlc.New(int64(num*2+1), 0))
+	// Cache should be empty
+	a.Equal(0, cache.impl.Len())
+}

--- a/internal/source/kafka/config.go
+++ b/internal/source/kafka/config.go
@@ -45,17 +45,18 @@ type EagerConfig Config
 // Config contains the configuration necessary for creating a
 // replication connection. ServerID and SourceConn are mandatory.
 type Config struct {
-	ConveyorConfig conveyor.Config
-	DLQ            dlq.Config
-	Script         script.Config
-	Sequencer      sequencer.Config
-	Staging        sinkprod.StagingConfig
-	Target         sinkprod.TargetConfig
-	TargetSchema   ident.Schema
-	TLS            secure.Config
+	Conveyor     conveyor.Config
+	DLQ          dlq.Config
+	Script       script.Config
+	Sequencer    sequencer.Config
+	Staging      sinkprod.StagingConfig
+	Target       sinkprod.TargetConfig
+	TargetSchema ident.Schema
+	TLS          secure.Config
 
 	BatchSize        int           // How many messages to accumulate before committing to the target
 	Brokers          []string      // The address of the Kafka brokers
+	CacheSize        int           // Size of the cache to track duplicate messages.
 	Group            string        // the Kafka consumer group id.
 	MaxTimestamp     string        // Only accept messages at or older than this timestamp
 	MinTimestamp     string        // Only accept messages at or newer than this timestamp
@@ -86,6 +87,7 @@ type SASLConfig struct {
 
 // Bind adds flags to the set. It delegates to the embedded Config.Bind.
 func (c *Config) Bind(f *pflag.FlagSet) {
+	c.Conveyor.Bind(f)
 	c.DLQ.Bind(f)
 	c.Script.Bind(f)
 	c.Sequencer.Bind(f)
@@ -96,6 +98,7 @@ func (c *Config) Bind(f *pflag.FlagSet) {
 
 	f.IntVar(&c.BatchSize, "batchSize", 100, "messages to accumulate before committing to the target")
 	f.StringArrayVar(&c.Brokers, "broker", nil, "address of Kafka broker(s)")
+	f.IntVar(&c.CacheSize, "cacheSize", 1e4, "size of the cache for de-duping, per partition")
 	f.StringVar(&c.Group, "group", "", "the Kafka consumer group id")
 	f.StringVar(&c.MaxTimestamp, "maxTimestamp", "",
 		"only accept messages older than this timestamp; this is an exclusive upper limit")

--- a/internal/source/kafka/conn.go
+++ b/internal/source/kafka/conn.go
@@ -67,6 +67,7 @@ func (c *Conn) Start(ctx *stopper.Context) (err error) {
 	c.consumer = &Consumer{
 		conveyor:  c.conveyor,
 		batchSize: c.config.BatchSize,
+		cacheSize: c.config.CacheSize,
 		schema:    c.config.TargetSchema,
 		timeRange: c.config.timeRange,
 		fromState: start,

--- a/internal/source/kafka/integration_test.go
+++ b/internal/source/kafka/integration_test.go
@@ -189,7 +189,7 @@ func getConfig(fixture *base.Fixture, fc *fixtureConfig, tgt ident.Table) (*Conf
 			ApplyTimeout: 2 * time.Minute, // Increase to make using the debugger easier.
 		},
 		TargetSchema: dbName,
-		ConveyorConfig: conveyor.Config{
+		Conveyor: conveyor.Config{
 			Immediate: fc.immediate,
 		},
 		BatchSize:        100,

--- a/internal/source/kafka/metrics.go
+++ b/internal/source/kafka/metrics.go
@@ -24,6 +24,32 @@ import (
 // TODO (silvano) Provide a grafana dashboard for kafka connector.
 // https://github.com/cockroachdb/replicator/issues/829
 var (
+	cacheSize = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "kafka_cache_size",
+		Help: "the number of entries in the cache",
+	}, []string{"topic", "partition"})
+	delayDuration = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "kafka_delay_seconds",
+		Help: "the delta between now and the latest resolved timestamp",
+	}, []string{"topic", "partition"})
+	duplicateMessagesCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "kafka_duplicate_count",
+		Help: "the total of duplicate messages",
+	}, []string{"topic", "partition"})
+	evictDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "kafka_cache_evictions_duration",
+		Help:    "the length of time it took to evict expired entries from the cache",
+		Buckets: prometheus.ExponentialBucketsRange(1, 1e6, 20),
+	}, []string{"topic", "partition"})
+	oldMessagesCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "kafka_old_messages_count",
+		Help: "the total of messages older than the last resolved timestamp",
+	}, []string{"topic", "partition"})
+	purgeDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "kafka_cache_purges_duration",
+		Help:    "the length of time it took to purge the cache",
+		Buckets: prometheus.ExponentialBucketsRange(1, 1e6, 20),
+	}, []string{"topic", "partition"})
 	seekMessagesCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "kafka_seeks_count",
 		Help: "the total of messages read seeking a minimum resolved timestamp",

--- a/internal/source/kafka/provider.go
+++ b/internal/source/kafka/provider.go
@@ -39,7 +39,7 @@ func ProvideEagerConfig(cfg *Config, _ *script.Loader) *EagerConfig {
 
 // ProvideConveyorConfig is called by Wire.
 func ProvideConveyorConfig(cfg *Config) *conveyor.Config {
-	return &cfg.ConveyorConfig
+	return &cfg.Conveyor
 }
 
 // ProvideConn is called by Wire to construct this package's


### PR DESCRIPTION
Under some conditions a changefeed will emit duplicate messages to ensure the sink is receiving each message at least once.
However, the duplicate messages may be sent after newer messages, possibly overriding or deleting rows.

This change adds buffering in the Kafka connector, keeping track of the timestamp for each key, ensuring that older values for a particular row do not override most recent ones.

The buffer is backed by LRU cache. When we receive a resolved timestamp, we evict from cache any entries that have a timestamp that is older than the resolved timestamp.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/917)
<!-- Reviewable:end -->
