### PR TITLE
go.mod: Update go to 1.22.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cockroachdb/replicator
 
-go 1.22.1
+go 1.22.4
 
 require (
 	github.com/IBM/sarama v1.43.2


### PR DESCRIPTION
This change updates the minimum go version to pick up some security-related fixes in the http and net packages.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/918)
<!-- Reviewable:end -->
