### PR TITLE
script: Allow custom routing of deletions

### DIFF
--- a/internal/script/loader.go
+++ b/internal/script/loader.go
@@ -49,6 +49,10 @@ type deleteKeyJS func(
 	meta map[string]any,
 ) ([]any, error)
 
+// A JS function that dispatches delete operations, analogous to
+// dispatchJS.
+type deletesToJS dispatchJS
+
 // A JS function to dispatch source documents onto target tables.
 //
 // Look on my Works, ye Mighty, and despair!
@@ -96,7 +100,7 @@ var (
 
 // sourceJS is used in the API binding.
 type sourceJS struct {
-	DeletesTo string     `goja:"deletesTo"`
+	DeletesTo goja.Value `goja:"deletesTo"` // A deletesToJS or a string.
 	Dispatch  dispatchJS `goja:"dispatch"`
 	Recurse   bool       `goja:"recurse"`
 	Target    string     `goja:"target"`

--- a/internal/script/testdata/main.ts
+++ b/internal/script/testdata/main.ts
@@ -24,7 +24,7 @@ import * as lib from "./lib";
 
 api.configureSource("expander", {
     dispatch: (doc, meta) => {
-        console.log(JSON.stringify(doc), JSON.stringify(meta));
+        console.log("dispatch:", JSON.stringify(doc), JSON.stringify(meta));
         console.log(api.randomUUID());
 
         return {
@@ -35,7 +35,23 @@ api.configureSource("expander", {
             ],
         };
     },
-    deletesTo: "table1"
+    // This returns a map of arrays of PKs to allow multiple rows to be
+    // deleted within a table.
+    deletesTo: (doc: api.Document, meta: api.Document): Record<api.Table, api.Document[]> => {
+        console.log("deletesTo:", JSON.stringify(doc), JSON.stringify(meta));
+        switch (meta.table) {
+            case "table1":
+                return {
+                    "table1": [doc],
+                    "table2": [{idx: 42}],
+                };
+            default:
+                // Passthrough.
+                let ret: Record<api.Table, api.Document[]> = {};
+                ret["" + meta.table] = [doc];
+                return ret;
+        }
+    },
 });
 
 api.configureSource("passthrough", {

--- a/internal/script/testdata/replicator@v1.d.ts
+++ b/internal/script/testdata/replicator@v1.d.ts
@@ -102,13 +102,24 @@ declare module "replicator@v1" {
         dispatch: (doc: Document, meta: Document) => Record<Table, Document[]> | null
 
         /**
-         * The destination table to apply deletion operations to. In
-         * cases when a dispatch function fans out an incoming document
-         * across multiple tables, an <code>ON DELETE CASCADE</code>
-         * foreign-key relationship should be used to ensure correct
-         * propagation.
+         * The destination table(s) to apply deletion operations to.
+         *
+         * In cases when a dispatch function fans out an incoming
+         * document across multiple tables, an <code>ON DELETE
+         * CASCADE</code> foreign-key relationship can be used to
+         * ensure correct propagation. This is useful for document
+         * stores where a document is mapped onto a table hierarchy.
+         *
+         * This value may also be a function which dynamically
+         * dispatches deletes. It will receive a sparse mutation
+         * containing the PK columns of the row to delete. It should
+         * return a mapping of destination table(s) to (sparse) records
+         * to delete. This callback may also return null to elide
+         * deletes from the source. The <code>meta.table</code> value
+         * can be used to determine the table that the delete would
+         * normally be dispatched to.
          */
-        deletesTo: Table
+        deletesTo: Table | ((doc: Document, meta: Document) => Record<Table, Document[]> | null)
     } | {
         /**
          * The name of a destination table.
@@ -223,11 +234,11 @@ declare module "replicator@v1" {
          */
         merge: MergeFunction | StandardMerge;
         /**
-          * This is a tuning parameter which allows the maximum number
-          * of rows in a single UPSERT or DELETE statement to be
-          * limited. This is mainly needed for ultra-wide tables and
-          * databases with a relatively small number of available bind
-          * variables. If unset, a reasonable value will be chosen.
+         * This is a tuning parameter which allows the maximum number
+         * of rows in a single UPSERT or DELETE statement to be
+         * limited. This is mainly needed for ultra-wide tables and
+         * databases with a relatively small number of available bind
+         * variables. If unset, a reasonable value will be chosen.
          */
         rowLimit: number;
     };

--- a/internal/sinktest/scripttest/testdata/logical_test.ts
+++ b/internal/sinktest/scripttest/testdata/logical_test.ts
@@ -17,7 +17,7 @@
  */
 
 import * as api from "cdc-sink@v1";
-import {Document, Table} from "cdc-sink@v1";
+import {Document, DocumentValue, Table} from "cdc-sink@v1";
 
 // The sentinel name will be replaced by the test rig. It would normally be
 // "my_db.public" or "my_db" depending on the target product.
@@ -33,7 +33,10 @@ api.configureSource("{{ SCHEMA }}", {
             }
         ];
         return ret
-    }
+    },
+    deletesTo: (doc: Document): Record<Table, Document[]> => ({
+        "{{ TABLE }}": [doc],
+    }),
 })
 
 // We introduce an unknown column in the dispatch function above.


### PR DESCRIPTION
This change adds an optional user callback to configureSource() that is like the dispatch function, but for deletes. It receives the keys of the records to delete and returns a mapping of tables to primary keys.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/925)
<!-- Reviewable:end -->
