### PR TITLE
sequencer/script: Ensure meta info is added to delete mutations

### DIFF
--- a/internal/sequencer/script/acceptor.go
+++ b/internal/sequencer/script/acceptor.go
@@ -100,6 +100,8 @@ func (a *acceptor) doDispatch(
 	nextBatch := &types.MultiBatch{}
 
 	for _, mutToDispatch := range batch.Data {
+		script.AddMeta(a.group.Name.Raw(), batch.Table, &mutToDispatch)
+
 		// Separate deletes from upserts for routing.
 		if mutToDispatch.IsDelete() {
 			deletesTo, err := source.DeletesTo(ctx, batch.Table, mutToDispatch)
@@ -119,7 +121,6 @@ func (a *acceptor) doDispatch(
 			continue
 		}
 
-		script.AddMeta(a.group.Name.Raw(), batch.Table, &mutToDispatch)
 		// Call the user function to see what mutations(s) go into which table(s).
 		dispatched, err := source.Dispatch(ctx, batch.Table, mutToDispatch)
 		if err != nil {

--- a/internal/sequencer/script/script_test.go
+++ b/internal/sequencer/script/script_test.go
@@ -80,11 +80,21 @@ func testUserScriptSequencer(t *testing.T, baseMode switcher.Mode) {
 			"main.ts": &fstest.MapFile{Data: []byte(`
 import * as api from "replicator@v1";
 api.configureSource("src1", {
-  dispatch: (doc) => ({
-    "T_1": [ doc ], // Note upper-case table name.
-    "t_2": [ doc ]
-  }),
-  deletesTo: "t_1"
+  dispatch: (doc, meta) => {
+    if (meta.table === undefined) {
+      throw "verify meta wiring";
+    }
+    return {
+      "T_1": [ doc ], // Note upper-case table name.
+      "t_2": [ doc ]
+    };
+  },
+  deletesTo: (doc, meta) => {
+    if (meta.table === undefined) {
+      throw "verify meta wiring";
+    }
+    return { "t_1" : [doc] };
+  },
 });
 api.configureTable("T_1", { // Upper-case table name.
   map: (doc) => {


### PR DESCRIPTION
The metata for a mutation was not being added to deletes passing through the script acceptor. This moves the computation up in the for loop and adds a test to validate the script acceptor wiring.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/930)
<!-- Reviewable:end -->
