### PR TITLE
logfmt: Improve log output ergonomics

### DIFF
--- a/internal/sinktest/base/log_config.go
+++ b/internal/sinktest/base/log_config.go
@@ -1,0 +1,39 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package base
+
+import (
+	golog "log"
+	"time"
+
+	"github.com/cockroachdb/replicator/internal/util/logfmt"
+	log "github.com/sirupsen/logrus"
+)
+
+// Provide reasonable defaults for logrus when testing.
+func init() {
+	pw := log.WithField("golog", true).Writer()
+	log.DeferExitHandler(func() { _ = pw.Close() })
+	// logrus will provide timestamp info.
+	golog.SetFlags(0)
+	golog.SetOutput(pw)
+
+	log.SetFormatter(logfmt.Wrap(&log.TextFormatter{
+		PadLevelText:    true,
+		TimestampFormat: time.Stamp,
+	}))
+}

--- a/internal/source/pglogical/integration_test.go
+++ b/internal/source/pglogical/integration_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/cockroachdb/replicator/internal/sinktest/scripttest"
 	"github.com/cockroachdb/replicator/internal/util/batches"
 	"github.com/cockroachdb/replicator/internal/util/ident"
-	"github.com/cockroachdb/replicator/internal/util/logfmt"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pkg/errors"
@@ -59,11 +58,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	log.SetFormatter(logfmt.Wrap(&log.TextFormatter{
-		FullTimestamp:   true,
-		PadLevelText:    true,
-		TimestampFormat: time.Stamp,
-	}))
 	all.IntegrationMain(m, all.PostgreSQLName)
 }
 

--- a/internal/util/logfmt/metrics.go
+++ b/internal/util/logfmt/metrics.go
@@ -1,0 +1,37 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package logfmt
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	messageCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "log_message_count",
+		Help: "the number of log messages emitted at the given level",
+	}, []string{"level"})
+)
+
+func init() {
+	// Ensure all levels are populated so we can graph a zero value.
+	for _, level := range log.AllLevels {
+		messageCount.WithLabelValues(level.String()).Add(0)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -72,6 +72,7 @@ func main() {
 				log.SetLevel(log.DebugLevel)
 			default:
 				log.SetLevel(log.TraceLevel)
+				log.SetReportCaller(true)
 			}
 
 			switch logFormat {

--- a/scripts/dashboard/replicator.json
+++ b/scripts/dashboard/replicator.json
@@ -630,12 +630,151 @@
       "type": "table"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "The rate of error and warning log messages.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 1,
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "mps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "error"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "warning"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 44,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (level)(rate(log_message_count{level=~\"error|warning\"}[$__rate_interval]))",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{level}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Errors and Warnings",
+      "type": "timeseries"
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 12
+        "y": 20
       },
       "id": 13,
       "panels": [
@@ -664,7 +803,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 2
+            "y": 21
           },
           "id": 14,
           "options": {
@@ -829,7 +968,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 2
+            "y": 21
           },
           "id": 15,
           "options": {
@@ -940,7 +1079,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 10
+            "y": 29
           },
           "id": 16,
           "options": {
@@ -1031,7 +1170,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 10
+            "y": 29
           },
           "id": 17,
           "options": {
@@ -1080,7 +1219,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 21
       },
       "id": 8,
       "panels": [
@@ -1109,7 +1248,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 38
+            "y": 46
           },
           "id": 10,
           "options": {
@@ -1277,7 +1416,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 38
+            "y": 46
           },
           "id": 11,
           "options": {
@@ -1392,7 +1531,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 46
+            "y": 54
           },
           "id": 9,
           "options": {
@@ -1465,7 +1604,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 52
+            "y": 60
           },
           "id": 32,
           "options": {
@@ -1533,7 +1672,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 58
+            "y": 66
           },
           "id": 12,
           "options": {
@@ -1601,7 +1740,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 64
+            "y": 72
           },
           "id": 21,
           "options": {
@@ -1650,7 +1789,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 22
       },
       "id": 29,
       "panels": [
@@ -1692,7 +1831,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 39
+            "y": 47
           },
           "id": 30,
           "options": {
@@ -1819,7 +1958,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 39
+            "y": 47
           },
           "id": 33,
           "options": {
@@ -1954,7 +2093,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 47
+            "y": 55
           },
           "id": 36,
           "options": {
@@ -2081,7 +2220,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 47
+            "y": 55
           },
           "id": 37,
           "options": {
@@ -2196,7 +2335,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 55
+            "y": 63
           },
           "id": 38,
           "options": {
@@ -2268,7 +2407,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 60
+            "y": 68
           },
           "id": 35,
           "options": {
@@ -2335,7 +2474,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 66
+            "y": 74
           },
           "id": 34,
           "options": {
@@ -2381,7 +2520,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 23
       },
       "id": 3,
       "panels": [
@@ -2410,7 +2549,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 16
+            "y": 24
           },
           "id": 2,
           "options": {
@@ -2524,8 +2663,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2579,7 +2717,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 16
+            "y": 24
           },
           "id": 5,
           "options": {
@@ -2681,8 +2819,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -2694,7 +2831,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 24
+            "y": 32
           },
           "id": 6,
           "options": {
@@ -2751,8 +2888,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2768,7 +2904,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 30
+            "y": 38
           },
           "id": 31,
           "options": {
@@ -2827,8 +2963,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2844,7 +2979,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 36
+            "y": 44
           },
           "id": 40,
           "options": {
@@ -2901,8 +3036,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red",
-                    "value": null
+                    "color": "red"
                   }
                 ]
               },
@@ -2914,7 +3048,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 42
+            "y": 50
           },
           "id": 7,
           "options": {
@@ -2963,7 +3097,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 24
       },
       "id": 18,
       "panels": [
@@ -2996,7 +3130,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 41
+            "y": 49
           },
           "id": 19,
           "options": {
@@ -3064,7 +3198,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 47
+            "y": 55
           },
           "id": 20,
           "options": {
@@ -3113,7 +3247,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 25
       },
       "id": 23,
       "panels": [
@@ -3179,7 +3313,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 42
+            "y": 50
           },
           "id": 27,
           "options": {
@@ -3287,7 +3421,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 42
+            "y": 50
           },
           "id": 26,
           "options": {
@@ -3421,7 +3555,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 50
+            "y": 58
           },
           "id": 24,
           "options": {
@@ -3583,7 +3717,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 50
+            "y": 58
           },
           "id": 25,
           "options": {
@@ -3675,7 +3809,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 58
+            "y": 66
           },
           "id": 28,
           "options": {
@@ -3720,7 +3854,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 26
       },
       "id": 41,
       "panels": [
@@ -3776,8 +3910,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -3827,7 +3960,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 51
+            "y": 59
           },
           "id": 42,
           "options": {
@@ -3961,8 +4094,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -3974,7 +4106,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 51
+            "y": 59
           },
           "id": 43,
           "options": {


### PR DESCRIPTION
This change adds a metrics counter to identify spikes in workload error rates. The dashboard is updated to graph errors and warnings.

Errors that are often a side-effect of some other malfunction are labeled with a "noisy" property to allow them to be filtered when log-mining.

Log messages will now include the source of the logging call when trace mode is enabled.

A default logging configuration is installed by the sinktest/base package.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/944)
<!-- Reviewable:end -->
