### PR TITLE
workflows: Replace docker-compose with docker compose

### DIFF
--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -212,7 +212,7 @@ jobs:
       - name: Start Containers
         working-directory: .github
         run: >
-          docker-compose up -d
+          docker compose up -d
           cockroachdb-${{ matrix.cockroachdb }}
           ${{ matrix.integration }}
           ${{ matrix.source }}
@@ -261,7 +261,7 @@ jobs:
       - name: Docker container logs
         if: always()
         working-directory: .github
-        run: docker-compose logs --no-color > ${{ env.DOCKER_LOGS_OUT }}
+        run: docker compose logs --no-color > ${{ env.DOCKER_LOGS_OUT }}
 
       # Upload all test reports to a common artifact name, to make them
       # available to the summarization step. The go test json is

--- a/scripts/dashboard/README.md
+++ b/scripts/dashboard/README.md
@@ -11,7 +11,7 @@ import the dashboard template.
 
 ## Quickstart
 
-* Execute `docker-compose --profile monitor up` to launch the containers.
+* Execute `docker compose --profile monitor up` to launch the containers.
 * Connect to `http://127.0.0.1:3000` and log in with "admin" as the
   username and password.
 * Add Prometheus as a data source:

--- a/scripts/docker_c2c/run_compose.sh
+++ b/scripts/docker_c2c/run_compose.sh
@@ -28,7 +28,7 @@ fi
 echo "export COCKROACH_DEV_LICENSE='"$COCKROACH_DEV_LICENSE"'" > scripts/crdb_env
 echo "export COCKROACH_DEV_ORGANIZATION='"$COCKROACH_DEV_ORGANIZATION"'" >> scripts/crdb_env
 
-docker-compose up --detach
+docker compose up --detach
 
 echo "Resetting Grafana Admin Password...."
 echo ""


### PR DESCRIPTION
The docker-compose command has become deprecated on the GitHub runners in favor of a "docker compose" subcommand. This change also updates some passing references to the command to reflect current usage.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/949)
<!-- Reviewable:end -->
