### PR TITLE
schemawatch: Refresh Watch method to return a notify.Var

### DIFF
--- a/internal/target/schemawatch/watcher.go
+++ b/internal/target/schemawatch/watcher.go
@@ -23,10 +23,11 @@ import (
 	"database/sql"
 	"flag"
 	"fmt"
-	"sync"
 	"time"
 
+	"github.com/cockroachdb/field-eng-powertools/notify"
 	"github.com/cockroachdb/field-eng-powertools/stopper"
+	"github.com/cockroachdb/field-eng-powertools/stopvar"
 	"github.com/cockroachdb/replicator/internal/types"
 	"github.com/cockroachdb/replicator/internal/util/ident"
 	"github.com/cockroachdb/replicator/internal/util/retry"
@@ -42,16 +43,9 @@ var RefreshDelay = flag.Duration("schemaRefresh", time.Minute,
 // A watcher maintains an internal cache of a database's schema,
 // allowing callers to receive notifications of schema changes.
 type watcher struct {
-	// All goroutines used by Watch use this as a parent context.
-	background *stopper.Context
-	delay      time.Duration
-	schema     ident.Schema
-
-	mu struct {
-		sync.RWMutex
-		data    *types.SchemaData
-		updated chan struct{} // Closed and replaced when data is updated.
-	}
+	data   *notify.Var[*types.SchemaData]
+	delay  time.Duration
+	schema ident.Schema
 }
 
 var _ types.Watcher = (*watcher)(nil)
@@ -61,18 +55,16 @@ var _ types.Watcher = (*watcher)(nil)
 // until the cancel callback is executed.
 func newWatcher(ctx *stopper.Context, tx *types.TargetPool, schema ident.Schema) (*watcher, error) {
 	w := &watcher{
-		background: ctx,
-		delay:      *RefreshDelay,
-		schema:     schema,
+		delay:  *RefreshDelay,
+		schema: schema,
 	}
-	w.mu.updated = make(chan struct{})
 
 	// Initial data load to sanity-check and make ready.
 	data, err := w.getTables(ctx, tx)
 	if err != nil {
 		return nil, err
 	}
-	w.mu.data = data
+	w.data = notify.VarOf(data)
 
 	if w.delay > 0 {
 		ctx.Go(func(ctx *stopper.Context) error {
@@ -94,42 +86,33 @@ func newWatcher(ctx *stopper.Context, tx *types.TargetPool, schema ident.Schema)
 
 // Get implements types.Watcher.
 func (w *watcher) Get() *types.SchemaData {
-	w.mu.RLock()
-	defer w.mu.RUnlock()
-	return w.mu.data
+	// Ignore notification channel.
+	ret, _ := w.data.Get()
+	return ret
 }
 
 // Refresh immediately refreshes the watcher's internal cache. This
 // is intended for use by tests.
 func (w *watcher) Refresh(ctx context.Context, tx *types.TargetPool) error {
-	data, err := w.getTables(ctx, tx)
+	next, err := w.getTables(ctx, tx)
 	if err != nil {
 		return err
 	}
 
-	w.mu.Lock()
-	defer w.mu.Unlock()
-
-	w.mu.data = data
-
-	// Close and replace the channel to create a broadcast effect.
-	close(w.mu.updated)
-	w.mu.updated = make(chan struct{})
-
+	w.data.Set(next)
 	return nil
 }
 
 // Snapshot returns the known tables in the given user-defined schema.
 func (w *watcher) Snapshot(in ident.Schema) *types.SchemaData {
-	w.mu.RLock()
-	defer w.mu.RUnlock()
+	data := w.Get()
 
 	ret := &types.SchemaData{
 		Columns: &ident.TableMap[[]types.ColData]{},
-		Order:   make([][]ident.Table, 0, len(w.mu.data.Order)),
+		Order:   make([][]ident.Table, 0, len(data.Order)),
 	}
 
-	_ = w.mu.data.Columns.Range(func(table ident.Table, cols []types.ColData) error {
+	_ = data.Columns.Range(func(table ident.Table, cols []types.ColData) error {
 		if in.Contains(table) {
 			// https://github.com/golang/go/wiki/SliceTricks#copy
 			out := make([]types.ColData, len(cols))
@@ -138,7 +121,7 @@ func (w *watcher) Snapshot(in ident.Schema) *types.SchemaData {
 		}
 		return nil
 	})
-	for _, tables := range w.mu.data.Order {
+	for _, tables := range data.Order {
 		filtered := make([]ident.Table, 0, len(tables))
 		for _, tbl := range tables {
 			if in.Contains(tbl) {
@@ -160,52 +143,45 @@ func (w *watcher) String() string {
 // Watch will send updated column data for the given table until the
 // watch is canceled. The requested table must already be known to the
 // watcher.
-func (w *watcher) Watch(table ident.Table) (<-chan []types.ColData, func(), error) {
-	w.mu.RLock()
-	defer w.mu.RUnlock()
-	if _, ok := w.mu.data.Columns.Get(table); !ok {
-		return nil, nil, errors.Errorf("unknown table %s", table)
+func (w *watcher) Watch(
+	ctx *stopper.Context, table ident.Table,
+) (*notify.Var[[]types.ColData], error) {
+	snapshot := w.Get()
+	lastCols, ok := snapshot.Columns.Get(table)
+	if !ok {
+		return nil, errors.Errorf("unknown table %s", table)
 	}
-
-	ctx := stopper.WithContext(w.background)
-	ch := make(chan []types.ColData, 1)
+	into := notify.VarOf(lastCols)
 
 	ctx.Go(func(ctx *stopper.Context) error {
-		defer close(ch)
+		_, _ = stopvar.DoWhenChanged(ctx, snapshot, w.data, func(ctx *stopper.Context, _, next *types.SchemaData) error {
+			nextCols, ok := next.Columns.Get(table)
 
-		var last []types.ColData
-		for {
-			w.mu.RLock()
-			next, ok := w.mu.data.Columns.Get(table)
-			updated := w.mu.updated
-			w.mu.RUnlock()
+			// Respond to dropping the table.
+			if !ok {
+				log.Tracef("canceling schema watch for %s because it was dropped", table)
+				into.Set(nil)
+				// Returning any error to break out.
+				return context.Canceled
+			}
 
-			// Respond to context cancellation or dropping the table.
-			if !ok || ctx.Err() != nil {
+			// Suppress no-op updates.
+			if colSliceEqual(lastCols, nextCols) {
 				return nil
 			}
+			lastCols = nextCols
 
-			// We're read-locked, so this isn't hugely critical.
-			if !colSliceEqual(last, next) {
-				select {
-				case <-ctx.Stopping():
-					return nil
-				case ch <- next:
-					last = next
-				default:
-					log.WithField("target", table).Warn("ColData watcher excessively behind")
-				}
-			}
-
-			select {
-			case <-ctx.Stopping():
-				return nil
-			case <-updated:
-				continue
-			}
-		}
+			// Emit a copy of the slice, to ensure the above
+			// comparison can't be affected by any pruning.
+			cpy := make([]types.ColData, len(nextCols))
+			copy(cpy, nextCols)
+			into.Set(cpy)
+			return nil
+		})
+		return nil
 	})
-	return ch, func() { ctx.Stop(100 * time.Millisecond) }, nil
+
+	return into, nil
 }
 
 const (

--- a/internal/types/acceptors_test.go
+++ b/internal/types/acceptors_test.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/field-eng-powertools/notify"
+	"github.com/cockroachdb/field-eng-powertools/stopper"
 	"github.com/cockroachdb/replicator/internal/sinktest/recorder"
 	"github.com/cockroachdb/replicator/internal/types"
 	"github.com/cockroachdb/replicator/internal/util/hlc"
@@ -110,9 +112,11 @@ type fakeWatcher struct {
 }
 
 func (w *fakeWatcher) Get() *types.SchemaData { return w.data }
-func (w *fakeWatcher) Refresh(ctx context.Context, pool *types.TargetPool) error {
+func (w *fakeWatcher) Refresh(_ context.Context, _ *types.TargetPool) error {
 	return errors.New("unimplemented")
 }
-func (w *fakeWatcher) Watch(table ident.Table) (_ <-chan []types.ColData, cancel func(), _ error) {
-	return nil, nil, errors.New("unimplemented")
+func (w *fakeWatcher) Watch(
+	_ *stopper.Context, _ ident.Table,
+) (*notify.Var[[]types.ColData], error) {
+	return nil, errors.New("unimplemented")
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -476,9 +476,11 @@ type Watcher interface {
 	// for updated schema information. This is intended for testing and
 	// does not need to be called in the general case.
 	Refresh(context.Context, *TargetPool) error
-	// Watch returns a channel that emits updated column data for the
-	// given table.  The channel will be closed if there
-	Watch(table ident.Table) (_ <-chan []ColData, cancel func(), _ error)
+	// Watch returns an initialized variable that will be kept up to
+	// date until the context is stopped or the table is dropped. If the
+	// table is dropped, a zero-length slice will be emitted as a final
+	// update. An error will be returned if the table is unknown.
+	Watch(ctx *stopper.Context, table ident.Table) (*notify.Var[[]ColData], error)
 }
 
 // Watchers is a factory for Watcher instances.


### PR DESCRIPTION
This change updates the Watcher.Watch() method to return a notify.Var to make it consistent with other sources of asynchronous updates. This will make a follow-on change to cache the target's schema cleaner to implement.

X-Ref: #902

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/952)
<!-- Reviewable:end -->
