### PR TITLE
stage: Add optional staging table consistency checks

### DIFF
--- a/internal/sequencer/seqtest/check.go
+++ b/internal/sequencer/seqtest/check.go
@@ -160,6 +160,7 @@ type Check struct {
 }
 
 // Check generates data and verifies that it reaches the target tables.
+// It will also ensure that the staging tables are in a correct state.
 func (c *Check) Check(ctx *stopper.Context, t testing.TB, cfg *all.WorkloadConfig) {
 	r := require.New(t)
 
@@ -247,4 +248,12 @@ func (c *Check) Check(ctx *stopper.Context, t testing.TB, cfg *all.WorkloadConfi
 	log.Infof("caught up in an additional %s", time.Since(now))
 	generator.CheckConsistent(ctx, t)
 
+	for _, table := range []ident.Table{generator.Parent.Name(), generator.Child.Name()} {
+		stager, err := c.Fixture.Stagers.Get(ctx, table)
+		r.NoError(err)
+		ct, err := stager.CheckConsistency(ctx,
+			c.Fixture.StagingPool, nil /* all records */, false /* current-time read */)
+		r.NoError(err, table)
+		r.Zero(ct, table)
+	}
 }

--- a/internal/source/cdc/handler_test.go
+++ b/internal/source/cdc/handler_test.go
@@ -23,6 +23,7 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -34,6 +35,7 @@ import (
 	"github.com/cockroachdb/replicator/internal/sinktest/all"
 	"github.com/cockroachdb/replicator/internal/sinktest/base"
 	"github.com/cockroachdb/replicator/internal/sinktest/scripttest"
+	"github.com/cockroachdb/replicator/internal/staging/stage"
 	"github.com/cockroachdb/replicator/internal/target/apply"
 	"github.com/cockroachdb/replicator/internal/types"
 	"github.com/cockroachdb/replicator/internal/util/applycfg"
@@ -50,6 +52,11 @@ type fixtureConfig struct {
 	discard   bool
 	immediate bool
 	script    bool
+}
+
+func TestMain(m *testing.M) {
+	stage.EnableSanityChecks()
+	os.Exit(m.Run())
 }
 
 func TestHandler(t *testing.T) {

--- a/internal/staging/stage/consistency.go
+++ b/internal/staging/stage/consistency.go
@@ -1,0 +1,97 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package stage
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/cockroachdb/replicator/internal/types"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+var extraSanityChecks = os.Getenv("REPLICATOR_SANITY_CHECKS") != ""
+
+// EnableSanityChecks can be called by test code to enable additional
+// validation of the staging tables.
+func EnableSanityChecks() {
+	extraSanityChecks = true
+}
+
+const checkTemplate = `
+WITH o AS (
+  SELECT nanos, logical, key,
+         row_number() OVER (PARTITION BY key ORDER BY nanos, logical) source_order,
+         row_number() OVER (PARTITION BY key ORDER BY applied_at NULLS LAST, nanos, logical) apply_order
+    FROM %[1]s
+    %[2]s
+)
+SELECT key, count(*)
+  FROM o %[3]s
+ WHERE source_order != apply_order
+ GROUP BY key
+`
+
+// CheckConsistency implements [types.Stager].
+func (s *stage) CheckConsistency(
+	ctx context.Context, db types.StagingQuerier, muts []types.Mutation, followerRead bool,
+) (int, error) {
+	var aost, in string
+	var args []any
+	if followerRead {
+		aost = "AS OF SYSTEM TIME follower_read_timestamp()"
+	}
+	if len(muts) > 0 {
+		in = "WHERE key IN (SELECT unnest($1::STRING[]))"
+
+		keys := make([]string, len(muts))
+		for idx, mut := range muts {
+			keys[idx] = string(mut.Key)
+		}
+		args = []any{keys}
+	}
+	q := fmt.Sprintf(checkTemplate, s.stage.Base, in, aost)
+	rows, err := db.Query(ctx, q, args...)
+	if err != nil {
+		return 0, errors.WithStack(err)
+	}
+	var count int
+	trace := log.IsLevelEnabled(log.TraceLevel)
+
+	for rows.Next() {
+		var key string
+		var keyCount int
+		if err := rows.Scan(&key, &keyCount); err != nil {
+			return 0, errors.WithStack(err)
+		}
+		count += keyCount
+		if trace {
+			log.WithFields(log.Fields{
+				"count": keyCount,
+				"table": s.stage.Base,
+				"key":   key,
+			}).Trace("consistency check failed")
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return 0, errors.WithStack(err)
+	}
+
+	return count, nil
+}

--- a/internal/staging/stage/consistency_test.go
+++ b/internal/staging/stage/consistency_test.go
@@ -1,0 +1,77 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package stage_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/cockroachdb/replicator/internal/sinktest/all"
+	"github.com/cockroachdb/replicator/internal/staging/stage"
+	"github.com/cockroachdb/replicator/internal/types"
+	"github.com/cockroachdb/replicator/internal/util/hlc"
+	"github.com/cockroachdb/replicator/internal/util/ident"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsistency(t *testing.T) {
+	stage.EnableSanityChecks()
+
+	r := require.New(t)
+
+	fixture, err := all.NewFixture(t)
+	r.NoError(err)
+
+	ctx := fixture.Context
+	pool := fixture.StagingPool
+	targetDB := fixture.StagingDB.Schema()
+	dummyTarget := ident.NewTable(targetDB, ident.New("target"))
+
+	s, err := fixture.Stagers.Get(ctx, dummyTarget)
+	r.NoError(err)
+	r.NotNil(s)
+
+	// Stage multiple mutations for the same key.
+	key := json.RawMessage(`[ 1 ]`)
+	muts := []types.Mutation{
+		{Key: key, Time: hlc.New(1, 1)},
+		{Key: key, Time: hlc.New(2, 2)},
+		{Key: key, Time: hlc.New(3, 3)},
+		{Key: key, Time: hlc.New(4, 4)},
+	}
+	r.NoError(s.Stage(ctx, pool, muts))
+
+	// Apply mutation 1; this would create a gap.
+	r.ErrorContains(s.MarkApplied(ctx, pool, muts[1:2]), "consistency check failed")
+
+	// Apply mutations 0.
+	r.NoError(s.MarkApplied(ctx, pool, muts[0:1]))
+
+	// Apply mutation 2; this would create a gap.
+	r.ErrorContains(s.MarkApplied(ctx, pool, muts[2:3]), "consistency check failed")
+
+	// Apply mutation 1 and then 2.
+	r.NoError(s.MarkApplied(ctx, pool, muts[1:2]))
+	r.NoError(s.MarkApplied(ctx, pool, muts[2:3]))
+
+	// Attempt to re-apply mutation 0 and 1.
+	r.ErrorContains(s.MarkApplied(ctx, pool, muts[0:1]), "consistency check failed")
+	r.ErrorContains(s.MarkApplied(ctx, pool, muts[1:2]), "consistency check failed")
+
+	// Re-marking the tail isn't an error.
+	r.NoError(s.MarkApplied(ctx, pool, muts[2:3]))
+}

--- a/internal/staging/stage/metrics.go
+++ b/internal/staging/stage/metrics.go
@@ -23,6 +23,10 @@ import (
 )
 
 var (
+	stageConsistencyErrors = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "stage_consistency_error_count",
+		Help: "the number of staging table rows with inconsistent source and apply times",
+	}, metrics.TableLabels)
 	stageFilterAppliedDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "stage_filter_applied_duration_seconds",
 		Help:    "the SQL statement execution time to detect already-applied mutations",

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -150,6 +150,11 @@ type MutationFilter func(Mutation) bool
 // Stager describes a service which can durably persist some
 // number of Mutations.
 type Stager interface {
+	// CheckConsistency scans the staging table to ensure that it
+	// internally consistent. The number of inconsistent staging table
+	// entries will be returned.
+	CheckConsistency(ctx context.Context, db StagingQuerier, muts []Mutation, followerRead bool) (int, error)
+
 	// FilterApplied performs an anti-join against the staging table to
 	// return only unapplied mutations. This method will return a new
 	// slice.


### PR DESCRIPTION
This change adds a sanity check to the staging package to ensure that the staging table entries are marked as applied in an order which is consistent with the order in which the entries are staged. This check is optionally enabled in Stager.MarkApplied() by an environment variable. The check is also used to drive a monitoring metric.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/957)
<!-- Reviewable:end -->
