### PR TITLE
stage: Prevent table reader from jumping backwards

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -232,8 +232,9 @@ func (c *StagingCursor) String() string {
 type StagingQuery struct {
 	// The bounds variable governs the reader to ensure that it does not
 	// read beyond the data known to be consistent, by pausing reads
-	// when the maximum time has been reached. The minimum value of the
-	// bounds may be updated to optimize database scans.
+	// when the maximum time has been reached. Updates to the minimum
+	// bound allows records to be skipped, but a query cannot be rewound
+	// such that it will re-emit records.
 	Bounds *notify.Var[hlc.Range]
 
 	// FragmentSize places an upper bound on the size of any individual


### PR DESCRIPTION
It is possible for a reader to re-emit rows in subsequent cursors if it has reached an idle state and the bounds variable is updated without advancing the minimum value. This will happen if a slow target database delays the resolved timestamp bound from advancing before a new resolved timestamp is accepted for processing.

This change updates the behavior of the table reader such that it will not re-emit rows, regardless of how the bounds variable is driven.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/959)
<!-- Reviewable:end -->
