### PR TITLE
types: Add check to OrderedAcceptor for unknown tables

### DIFF
--- a/internal/types/acceptors_test.go
+++ b/internal/types/acceptors_test.go
@@ -94,6 +94,16 @@ func TestOrderedAcceptor(t *testing.T) {
 		}
 	}
 	r.Equal(levels-1, expectedLevelIdx)
+
+	// Detect cases where an unknown table is present in the input.
+	unknownTable := ident.NewTable(schema, ident.New("unknown"))
+	badBatch := &types.MultiBatch{}
+	r.NoError(badBatch.Accumulate(unknownTable, types.Mutation{
+		Time: hlc.New(1, 1),
+	}))
+	r.ErrorContains(
+		acc.AcceptMultiBatch(ctx, badBatch, &types.AcceptOptions{}),
+		"unable to determine apply order")
 }
 
 type fakeWatchers struct {


### PR DESCRIPTION
This change adds a sanity check for tables that have no defined apply order. This prevents a case where, depending on how the acceptor chain is constructed, mutations for unknown tables could be silently ignored.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/970)
<!-- Reviewable:end -->
