### PR TITLE
sequencer/script: Remove unnecessary table ordering

### DIFF
--- a/internal/sequencer/script/acceptor.go
+++ b/internal/sequencer/script/acceptor.go
@@ -36,7 +36,6 @@ type acceptor struct {
 	justMap    bool
 	targetPool *types.TargetPool
 	userScript *script.UserScript
-	watchers   types.Watchers
 }
 
 var _ types.TableAcceptor = (*acceptor)(nil)
@@ -149,7 +148,7 @@ func (a *acceptor) doDispatch(
 	cpy := *a
 	cpy.justMap = true
 
-	return types.OrderedAcceptorFrom(&cpy, a.watchers).AcceptMultiBatch(ctx, nextBatch, opts)
+	return types.UnorderedAcceptorFrom(&cpy).AcceptMultiBatch(ctx, nextBatch, opts)
 }
 
 func (a *acceptor) doMap(

--- a/internal/sequencer/script/script.go
+++ b/internal/sequencer/script/script.go
@@ -99,14 +99,13 @@ func (w *wrapper) Start(
 		})
 
 		opts = opts.Copy()
-		opts.Delegate = types.OrderedAcceptorFrom(&acceptor{
+		opts.Delegate = types.UnorderedAcceptorFrom(&acceptor{
 			delegate:   opts.Delegate,
 			ensureTX:   ensureTX,
 			group:      opts.Group,
 			targetPool: w.targetPool,
 			userScript: scr,
-			watchers:   w.watchers,
-		}, w.watchers)
+		})
 	}
 	return w.delegate.Start(ctx, opts)
 }

--- a/internal/types/acceptors.go
+++ b/internal/types/acceptors.go
@@ -47,8 +47,9 @@ type MultiAcceptor interface {
 }
 
 // OrderedAcceptorFrom will return an adaptor which iterates over tables
-// in the table-dependency order. The returned acceptor will respect the
-// [AcceptOptions.TableOrder] when iterating within a [TemporalBatch].
+// in the table-dependency order as determined by the schema watcher.
+//
+// See also [UnorderedAcceptorFrom].
 func OrderedAcceptorFrom(acc TableAcceptor, watchers Watchers) MultiAcceptor {
 	return &orderedAdapter{acc, watchers}
 }
@@ -140,5 +141,40 @@ func (t *orderedAdapter) AcceptMultiBatch(
 		}
 	}
 
+	return nil
+}
+
+// UnorderedAcceptorFrom adapts a [TableAcceptor] to the [MultiAcceptor]
+// interface. Table data will be delivered in an arbitrary order.
+func UnorderedAcceptorFrom(acc TableAcceptor) MultiAcceptor {
+	return &unorderedAdapter{acc}
+}
+
+type unorderedAdapter struct {
+	TableAcceptor
+}
+
+var _ MultiAcceptor = (*unorderedAdapter)(nil)
+
+func (u *unorderedAdapter) AcceptMultiBatch(
+	ctx context.Context, batch *MultiBatch, opts *AcceptOptions,
+) error {
+	for _, temp := range batch.Data {
+		if err := u.AcceptTemporalBatch(ctx, temp, opts); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (u *unorderedAdapter) AcceptTemporalBatch(
+	ctx context.Context, batch *TemporalBatch, opts *AcceptOptions,
+) error {
+	if err := batch.Data.Range(func(table ident.Table, tableBatch *TableBatch) error {
+		err := u.AcceptTableBatch(ctx, tableBatch, opts)
+		return errors.Wrapf(err, "%s @ %s", table.Raw(), batch.Time)
+	}); err != nil {
+		return err
+	}
 	return nil
 }

--- a/internal/types/acceptors_test.go
+++ b/internal/types/acceptors_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/replicator/internal/types"
 	"github.com/cockroachdb/replicator/internal/util/hlc"
 	"github.com/cockroachdb/replicator/internal/util/ident"
+	"github.com/cockroachdb/replicator/internal/util/workload"
 	"github.com/stretchr/testify/require"
 )
 
@@ -94,6 +95,34 @@ func TestOrderedAcceptor(t *testing.T) {
 		}
 	}
 	r.Equal(levels-1, expectedLevelIdx)
+}
+
+func TestUnorderedAcceptor(t *testing.T) {
+	const batches = 1000
+	r := require.New(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	schema := ident.MustSchema(ident.New("my_db"), ident.New("public"))
+
+	gen := workload.NewGeneratorBase(
+		ident.NewTable(schema, ident.New("parent")),
+		ident.NewTable(schema, ident.New("child")))
+	batch := &types.MultiBatch{}
+	for i := range batches {
+		gen.GenerateInto(batch, hlc.New(int64(i+1), i))
+	}
+
+	rec := &recorder.Recorder{}
+	acc := types.UnorderedAcceptorFrom(rec)
+	r.NoError(acc.AcceptMultiBatch(ctx, batch, &types.AcceptOptions{}))
+	r.Equal(batch.Count(), rec.Count())
+	for _, call := range rec.Calls() {
+		r.NotNil(call.Table)
+		r.Nil(call.Multi)
+		r.Nil(call.Temporal)
+	}
 }
 
 type fakeWatchers struct {


### PR DESCRIPTION
The userscript doesn't actually need to iterate over incoming batches in any particular order. This change replaces the use of OrderedAcceptorFrom() with a new UnorderedAcceptorFrom() that merely adapts the TableAcceptor type to a MultiAcceptor. This will allow the script to better interface with as-yet-unknown tables when addressing partitioned, fan-in use cases.

An outdated doc comment on OrderedAcceptorFrom() is corrected.

See also #970

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/971)
<!-- Reviewable:end -->
