### PR TITLE
Replicator: Support fan-in and wide-deletion use cases

### DIFF
--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -144,6 +144,7 @@ jobs:
           # Test CRDB via a Kafka cluster
           - cockroachdb: v24.1
             integration: kafka-v7.6
+            experimental: true # TODO: Investigate connection-refused errors
           # Test CRDB via an object store
           - cockroachdb: v24.1
             integration: objstore

--- a/internal/conveyor/provider.go
+++ b/internal/conveyor/provider.go
@@ -19,6 +19,7 @@ package conveyor
 import (
 	"github.com/cockroachdb/field-eng-powertools/stopper"
 	"github.com/cockroachdb/replicator/internal/sequencer/retire"
+	"github.com/cockroachdb/replicator/internal/sequencer/script"
 	"github.com/cockroachdb/replicator/internal/sequencer/switcher"
 	"github.com/cockroachdb/replicator/internal/staging/checkpoint"
 	"github.com/cockroachdb/replicator/internal/target/apply"
@@ -35,6 +36,7 @@ func ProvideConveyors(
 	acc *apply.Acceptor,
 	cfg *Config,
 	checkpoints *checkpoint.Checkpoints,
+	script *script.Sequencer,
 	retire *retire.Retire,
 	sw *switcher.Switcher,
 	watchers types.Watchers,
@@ -46,6 +48,7 @@ func ProvideConveyors(
 		cfg:           cfg,
 		checkpoints:   checkpoints,
 		retire:        retire,
+		script:        script,
 		stopper:       ctx,
 		switcher:      sw,
 		tableAcceptor: acc,

--- a/internal/script/applier.go
+++ b/internal/script/applier.go
@@ -187,8 +187,7 @@ func opsIntoBatch(ctx context.Context, ops []*applyOp, batch *types.TableBatch) 
 		}
 		switch applyAction(strings.ToLower(op.Action)) {
 		case actionDelete:
-			// Absence of data means delete.
-			batch.Data[idx].Data = nil
+			batch.Data[idx].Deletion = true
 		case actionUpsert:
 			// OK.
 		default:

--- a/internal/script/provider.go
+++ b/internal/script/provider.go
@@ -103,6 +103,9 @@ func ProvideLoader(
 	if err := apiModule.Set("randomUUID", randomUUID); err != nil {
 		return nil, err
 	}
+	if err := apiModule.Set(replicationKeyName, replicationKeyValue); err != nil {
+		return nil, err
+	}
 	if err := apiModule.Set("setOptions", l.setOptions); err != nil {
 		return nil, err
 	}

--- a/internal/script/testdata/main.ts
+++ b/internal/script/testdata/main.ts
@@ -45,17 +45,47 @@ api.configureSource("expander", {
                     "table1": [doc],
                     "table2": [{idx: 42}],
                 };
+            case "not_in_target_schema":
+                // This demonstrates how an incoming mutation with no
+                // corresponding target table is presented to the
+                // script. This will happen, say, if partitioned source
+                // tables are being fanned into a single destination
+                // table.
+                let key = doc[api.replicationKey];
+                if (!Array.isArray(key)) {
+                    throw "did not find expected replication key " + typeof key;
+                }
+                // This would represent some deployment-specific logic
+                // where the userscript is able to produce a deletion
+                // document from some data embedded in the key array.
+                return {"table1": [{"msg": key[0]}]};
             default:
-                // Passthrough.
-                let ret: Record<api.Table, api.Document[]> = {};
-                ret["" + meta.table] = [doc];
-                return ret;
+                // Basic pass-through case.
+                return {["" + meta.table]: [doc]};
         }
     },
 });
 
 api.configureSource("passthrough", {
     target: "some_table"
+});
+
+const splitPartition = /^(.*)_\d+$/;
+
+// trimPartition will look for tables named "my_table_1234" to dispatch
+// mutations to "my_table".
+function trimPartition(doc: api.Document, meta: api.Document): Record<api.Table, api.Document[]> {
+    let table = "" + meta.table;
+    let match = table.match(splitPartition);
+    if (match !== null) {
+        table = match[1];
+    }
+    return {[table]: [doc]};
+}
+
+api.configureSource("partitioned", {
+    dispatch: trimPartition,
+    deletesTo: trimPartition,
 });
 
 api.configureSource("recursive", {

--- a/internal/script/testdata/replicator@v1.d.ts
+++ b/internal/script/testdata/replicator@v1.d.ts
@@ -25,6 +25,14 @@
  */
 declare module "replicator@v1" {
     /**
+     * This is a sentinel property key that may be present in the
+     * document passed to a deletesTo() callback if the incoming
+     * mutation does not have a body and there is no obvious target
+     * table schema to synthesize a document based on the key.
+     */
+    const replicationKey: string;
+
+    /**
      * The name of a SQL column.
      */
     type Column = string;
@@ -116,8 +124,15 @@ declare module "replicator@v1" {
          * return a mapping of destination table(s) to (sparse) records
          * to delete. This callback may also return null to elide
          * deletes from the source. The <code>meta.table</code> value
-         * can be used to determine the table that the delete would
+         * can be used to determine the table that the deletion would
          * normally be dispatched to.
+         *
+         * In cases where an incoming deletion is associated with
+         * a source table that does not exist in the target schema,
+         * it may not be possible to convert the mutation's replication
+         * key into a fully-formed document. In this case, the doc parameter
+         * will contain a single key {@link replicationKey} containing
+         * the mutation's replication key.
          */
         deletesTo: Table | ((doc: Document, meta: Document) => Record<Table, Document[]> | null)
     } | {

--- a/internal/sequencer/script/script_test.go
+++ b/internal/sequencer/script/script_test.go
@@ -145,8 +145,9 @@ api.configureTable("t_2", {
 		Bounds:   bounds,
 		Delegate: types.OrderedAcceptorFrom(fixture.ApplyAcceptor, fixture.Watchers),
 		Group: &types.TableGroup{
-			Name:   ident.New("src1"), // Aligns with configureSource() call.
-			Tables: tgts[:1],          // Only drive from the 0th table
+			Enclosing: fixture.TargetSchema.Schema(),
+			Name:      ident.New("src1"), // Aligns with configureSource() call.
+			Tables:    tgts,
 		},
 	})
 	r.NoError(err)

--- a/internal/sequencer/script/source_acceptor.go
+++ b/internal/sequencer/script/source_acceptor.go
@@ -1,0 +1,95 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package script
+
+import (
+	"context"
+
+	"github.com/cockroachdb/replicator/internal/script"
+	"github.com/cockroachdb/replicator/internal/types"
+	"github.com/cockroachdb/replicator/internal/util/ident"
+	"github.com/pkg/errors"
+)
+
+// A sourceAcceptor is responsible for the actions wired up to a
+// configureSource() api call. Specifically, the sourceAcceptor is
+// concerned with routing incoming mutations to the correct
+// staging and/or target table.
+type sourceAcceptor struct {
+	delegate       types.MultiAcceptor
+	group          *types.TableGroup
+	sourceBindings *script.Source
+	watcher        types.Watcher
+}
+
+var _ types.TableAcceptor = (*sourceAcceptor)(nil)
+
+func (a *sourceAcceptor) AcceptTableBatch(
+	ctx context.Context, batch *types.TableBatch, opts *types.AcceptOptions,
+) error {
+	// We're going to construct a new batch from the dispatched mutations.
+	nextBatch := &types.MultiBatch{}
+
+	for _, mutToDispatch := range batch.Data {
+		script.AddMeta(a.group.Name.Raw(), batch.Table, &mutToDispatch)
+
+		isDelete := mutToDispatch.IsDelete()
+
+		dispatch := a.sourceBindings.Dispatch
+		fnName := "dispatch"
+		if isDelete {
+			// Same underlying func signature.
+			dispatch = script.Dispatch(a.sourceBindings.DeletesTo)
+			fnName = "deletesTo"
+		}
+
+		// Call the user function to see what mutations(s) go into which table(s).
+		dispatched, err := dispatch(ctx, batch.Table, mutToDispatch)
+		if err != nil {
+			return err
+		}
+		// Push the mutations into the replacement batch.
+		if err := dispatched.Range(func(table ident.Table, muts []types.Mutation) error {
+			if table.Empty() {
+				return errors.Errorf("%s returned an empty table name", fnName)
+			}
+			if _, found := a.watcher.Get().Columns.Get(table); !found {
+				return errors.Errorf(
+					"%s returned a table (%s) which does not exist in the target schema",
+					fnName, table)
+			}
+			for _, dispatchedMut := range muts {
+				dispatchedMut.Deletion = isDelete
+				// If the time were unset, it would trigger an error.
+				dispatchedMut.Time = mutToDispatch.Time
+				if err := nextBatch.Accumulate(table, dispatchedMut); err != nil {
+					return err
+				}
+			}
+			return err
+		}); err != nil {
+			return errors.Wrap(err, a.group.Name.Raw())
+		}
+	}
+	// Calls to source.Dispatch may remove mutations.
+	// If the replacement batch is empty, we are done.
+	if nextBatch.Count() == 0 {
+		return nil
+	}
+
+	return a.delegate.AcceptMultiBatch(ctx, nextBatch, opts)
+}

--- a/internal/sequencer/seqtest/wire_gen.go
+++ b/internal/sequencer/seqtest/wire_gen.go
@@ -56,7 +56,7 @@ func NewSequencerFixture(fixture *all.Fixture, config *sequencer.Config, scriptC
 		return nil, err
 	}
 	scriptSequencer := script2.ProvideSequencer(loader, targetPool, watchers)
-	switcherSwitcher := switcher.ProvideSequencer(bestEffort, coreCore, diagnostics, immediateImmediate, scriptSequencer, stagingPool, targetPool)
+	switcherSwitcher := switcher.ProvideSequencer(bestEffort, coreCore, diagnostics, immediateImmediate, stagingPool, targetPool)
 	seqtestFixture := &Fixture{
 		Fixture:    fixture,
 		BestEffort: bestEffort,

--- a/internal/sequencer/switcher/provider.go
+++ b/internal/sequencer/switcher/provider.go
@@ -48,7 +48,6 @@ func ProvideSequencer(
 	core *core.Core,
 	diags *diag.Diagnostics,
 	imm *immediate.Immediate,
-	script *script.Sequencer,
 	stagingPool *types.StagingPool,
 	targetPool *types.TargetPool,
 ) *Switcher {
@@ -57,7 +56,6 @@ func ProvideSequencer(
 		core:        core,
 		diags:       diags,
 		immediate:   imm,
-		script:      script,
 		stagingPool: stagingPool,
 		targetPool:  targetPool,
 	}

--- a/internal/sequencer/switcher/switcher.go
+++ b/internal/sequencer/switcher/switcher.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/replicator/internal/sequencer/besteffort"
 	"github.com/cockroachdb/replicator/internal/sequencer/core"
 	"github.com/cockroachdb/replicator/internal/sequencer/immediate"
-	"github.com/cockroachdb/replicator/internal/sequencer/script"
 	"github.com/cockroachdb/replicator/internal/types"
 	"github.com/cockroachdb/replicator/internal/util/diag"
 	"github.com/pkg/errors"
@@ -56,7 +55,6 @@ type Switcher struct {
 	core        *core.Core
 	diags       *diag.Diagnostics
 	immediate   *immediate.Immediate
-	script      *script.Sequencer
 	stagingPool *types.StagingPool
 	targetPool  *types.TargetPool
 
@@ -95,11 +93,7 @@ func (s *Switcher) Start(
 		s.diags.Unregister(diagName)
 	})
 
-	ret, err := s.script.Wrap(ctx, g)
-	if err != nil {
-		return nil, nil, err
-	}
-	return ret.Start(ctx, opts)
+	return g.Start(ctx, opts)
 }
 
 // WithMode returns a copy of the Switcher that uses the given variable

--- a/internal/sinktest/mutations/mutations.go
+++ b/internal/sinktest/mutations/mutations.go
@@ -96,6 +96,8 @@ func Generator(ctx context.Context, idCount int, deleteFraction float32) <-chan 
 					panic(err)
 				}
 				mut.Before = mut.Data
+			} else {
+				mut.Deletion = true
 			}
 
 			select {

--- a/internal/source/cdc/handler_test.go
+++ b/internal/source/cdc/handler_test.go
@@ -184,20 +184,38 @@ func testQueryHandler(t *testing.T, htc *fixtureConfig) {
 			if a.NoError(err) {
 				a.Len(muts, 2)
 				// The order is stable since the underlying query
-				// is ordered, in part, by the key.
-				a.Equal([]types.Mutation{
-					{
-						Data: []byte(`{"pk":42,"v":9007199254740995}`),
-						Key:  []byte(`[42]`),
-						Time: hlc.New(1, 0),
-					},
-					{
-						Before: []byte(`{"pk":99,"v":33}`),
-						Data:   []byte(`{"pk":99,"v":42}`),
-						Key:    []byte(`[99]`),
-						Time:   hlc.New(1, 0),
-					},
-				}, muts)
+				// orders, in part, on key. We will expect to see the
+				// effects of the userscript dispatch function, which
+				// is called prior to staging a mutation.
+				if htc.script {
+					a.Equal([]types.Mutation{
+						{
+							Data: []byte(`{"ignored":"by_configuration_below","pk":"42","v_dispatched":"9007199254740995"}`),
+							Key:  []byte(`["42"]`),
+							Time: hlc.New(1, 0),
+						},
+						{
+							Before: []byte(`{"pk":99,"v":33}`),
+							Data:   []byte(`{"ignored":"by_configuration_below","pk":"99","v_dispatched":"42"}`),
+							Key:    []byte(`["99"]`),
+							Time:   hlc.New(1, 0),
+						},
+					}, muts)
+				} else {
+					a.Equal([]types.Mutation{
+						{
+							Data: []byte(`{"pk":42,"v":9007199254740995}`),
+							Key:  []byte(`[42]`),
+							Time: hlc.New(1, 0),
+						},
+						{
+							Before: []byte(`{"pk":99,"v":33}`),
+							Data:   []byte(`{"pk":99,"v":42}`),
+							Key:    []byte(`[99]`),
+							Time:   hlc.New(1, 0),
+						},
+					}, muts)
+				}
 			}
 		}
 
@@ -254,20 +272,38 @@ func testQueryHandler(t *testing.T, htc *fixtureConfig) {
 			if a.NoError(err) {
 				a.Len(muts, 2)
 				// The order is stable since the underlying query
-				// orders by HLC and key.
-				a.Equal([]types.Mutation{
-					{
-						Data: []byte(`{"pk":42,"v":9007199254740995}`),
-						Key:  []byte(`[42]`),
-						Time: hlc.New(10, 0),
-					},
-					{
-						Before: []byte(`{"pk":99,"v":21}`),
-						Data:   []byte(`{"pk":99,"v":42}`),
-						Key:    []byte(`[99]`),
-						Time:   hlc.New(10, 0),
-					},
-				}, muts)
+				// orders, in part, on key. We will expect to see the
+				// effects of the userscript dispatch function, which
+				// is called prior to staging a mutation.
+				if htc.script {
+					a.Equal([]types.Mutation{
+						{
+							Data: []byte(`{"ignored":"by_configuration_below","pk":"42","v_dispatched":"9007199254740995"}`),
+							Key:  []byte(`["42"]`),
+							Time: hlc.New(10, 0),
+						},
+						{
+							Before: []byte(`{"pk":99,"v":21}`),
+							Data:   []byte(`{"ignored":"by_configuration_below","pk":"99","v_dispatched":"42"}`),
+							Key:    []byte(`["99"]`),
+							Time:   hlc.New(10, 0),
+						},
+					}, muts)
+				} else {
+					a.Equal([]types.Mutation{
+						{
+							Data: []byte(`{"pk":42,"v":9007199254740995}`),
+							Key:  []byte(`[42]`),
+							Time: hlc.New(10, 0),
+						},
+						{
+							Before: []byte(`{"pk":99,"v":21}`),
+							Data:   []byte(`{"pk":99,"v":42}`),
+							Key:    []byte(`[99]`),
+							Time:   hlc.New(10, 0),
+						},
+					}, muts)
+				}
 			}
 		}
 
@@ -386,20 +422,38 @@ func testHandler(t *testing.T, cfg *fixtureConfig) {
 			if a.NoError(err) {
 				a.Len(muts, 2)
 				// The order is stable since the underlying query
-				// orders, in part, on key
-				a.Equal([]types.Mutation{
-					{
-						Data: []byte(`{ "pk" : 42, "v" : 99 }`),
-						Key:  []byte(`[ 42 ]`),
-						Time: hlc.New(1, 0),
-					},
-					{
-						Before: []byte(`{ "pk" : 99, "v" : 33 }`),
-						Data:   []byte(`{ "pk" : 99, "v" : 42 }`),
-						Key:    []byte(`[ 99 ]`),
-						Time:   hlc.New(1, 0),
-					},
-				}, muts)
+				// orders, in part, on key. We will expect to see the
+				// effects of the userscript dispatch function, which
+				// is called prior to staging a mutation.
+				if cfg.script {
+					a.Equal([]types.Mutation{
+						{
+							Data: []byte(`{"ignored":"by_configuration_below","pk":"42","v_dispatched":"99"}`),
+							Key:  []byte(`["42"]`),
+							Time: hlc.New(1, 0),
+						},
+						{
+							Before: []byte(`{ "pk" : 99, "v" : 33 }`),
+							Data:   []byte(`{"ignored":"by_configuration_below","pk":"99","v_dispatched":"42"}`),
+							Key:    []byte(`["99"]`),
+							Time:   hlc.New(1, 0),
+						},
+					}, muts)
+				} else {
+					a.Equal([]types.Mutation{
+						{
+							Data: []byte(`{ "pk" : 42, "v" : 99 }`),
+							Key:  []byte(`[ 42 ]`),
+							Time: hlc.New(1, 0),
+						},
+						{
+							Before: []byte(`{ "pk" : 99, "v" : 33 }`),
+							Data:   []byte(`{ "pk" : 99, "v" : 42 }`),
+							Key:    []byte(`[ 99 ]`),
+							Time:   hlc.New(1, 0),
+						},
+					}, muts)
+				}
 			}
 		}
 
@@ -456,20 +510,38 @@ func testHandler(t *testing.T, cfg *fixtureConfig) {
 				hlc.RangeIncluding(hlc.Zero(), hlc.New(10, 1)))
 			if a.NoError(err) {
 				// The order is stable since the underlying query
-				// orders by HLC and key.
-				a.Equal([]types.Mutation{
-					{
-						Data: []byte(`{ "pk" : 42, "v" : 99 }`),
-						Key:  []byte(`[ 42 ]`),
-						Time: hlc.New(10, 0),
-					},
-					{
-						Before: []byte(`{ "pk" : 99, "v" : 21 }`),
-						Data:   []byte(`{ "pk" : 99, "v" : 42 }`),
-						Key:    []byte(`[ 99 ]`),
-						Time:   hlc.New(10, 0),
-					},
-				}, muts)
+				// orders, in part, on key. We will expect to see the
+				// effects of the userscript dispatch function, which
+				// is called prior to staging a mutation.
+				if cfg.script {
+					a.Equal([]types.Mutation{
+						{
+							Data: []byte(`{"ignored":"by_configuration_below","pk":"42","v_dispatched":"99"}`),
+							Key:  []byte(`["42"]`),
+							Time: hlc.New(10, 0),
+						},
+						{
+							Before: []byte(`{ "pk" : 99, "v" : 21 }`),
+							Data:   []byte(`{"ignored":"by_configuration_below","pk":"99","v_dispatched":"42"}`),
+							Key:    []byte(`["99"]`),
+							Time:   hlc.New(10, 0),
+						},
+					}, muts)
+				} else {
+					a.Equal([]types.Mutation{
+						{
+							Data: []byte(`{ "pk" : 42, "v" : 99 }`),
+							Key:  []byte(`[ 42 ]`),
+							Time: hlc.New(10, 0),
+						},
+						{
+							Before: []byte(`{ "pk" : 99, "v" : 21 }`),
+							Data:   []byte(`{ "pk" : 99, "v" : 42 }`),
+							Key:    []byte(`[ 99 ]`),
+							Time:   hlc.New(10, 0),
+						},
+					}, muts)
+				}
 			}
 		}
 

--- a/internal/source/cdc/wire_gen.go
+++ b/internal/source/cdc/wire_gen.go
@@ -71,18 +71,18 @@ func newTestFixture(fixture *all.Fixture, config *Config) (*testFixture, error) 
 	if err != nil {
 		return nil, err
 	}
-	retireRetire := retire.ProvideRetire(sequencerConfig, stagingPool, stagers)
-	coreCore := core.ProvideCore(sequencerConfig, typesLeases, schedulerScheduler, stagers, stagingPool, targetPool)
-	retryTarget := decorators.ProvideRetryTarget(targetPool)
-	immediateImmediate := immediate.ProvideImmediate(sequencerConfig, targetPool, marker, once, retryTarget, stagers)
 	scriptConfig := ProvideScriptConfig(config)
 	scriptLoader, err := script.ProvideLoader(context, configs, scriptConfig, diagnostics)
 	if err != nil {
 		return nil, err
 	}
 	sequencer := script2.ProvideSequencer(scriptLoader, targetPool, watchers)
-	switcherSwitcher := switcher.ProvideSequencer(bestEffort, coreCore, diagnostics, immediateImmediate, sequencer, stagingPool, targetPool)
-	conveyors, err := conveyor.ProvideConveyors(context, acceptor, conveyorConfig, checkpoints, retireRetire, switcherSwitcher, watchers)
+	retireRetire := retire.ProvideRetire(sequencerConfig, stagingPool, stagers)
+	coreCore := core.ProvideCore(sequencerConfig, typesLeases, schedulerScheduler, stagers, stagingPool, targetPool)
+	retryTarget := decorators.ProvideRetryTarget(targetPool)
+	immediateImmediate := immediate.ProvideImmediate(sequencerConfig, targetPool, marker, once, retryTarget, stagers)
+	switcherSwitcher := switcher.ProvideSequencer(bestEffort, coreCore, diagnostics, immediateImmediate, stagingPool, targetPool)
+	conveyors, err := conveyor.ProvideConveyors(context, acceptor, conveyorConfig, checkpoints, sequencer, retireRetire, switcherSwitcher, watchers)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/source/kafka/wire_gen.go
+++ b/internal/source/kafka/wire_gen.go
@@ -90,6 +90,7 @@ func Start(ctx *stopper.Context, config *Config) (*Kafka, error) {
 	if err != nil {
 		return nil, err
 	}
+	sequencer := script2.ProvideSequencer(loader, targetPool, watchers)
 	sequencerConfig := &eagerConfig.Sequencer
 	stagers := stage.ProvideFactory(stagingPool, stagingSchema, ctx)
 	retireRetire := retire.ProvideRetire(sequencerConfig, stagingPool, stagers)
@@ -107,9 +108,8 @@ func Start(ctx *stopper.Context, config *Config) (*Kafka, error) {
 	coreCore := core.ProvideCore(sequencerConfig, typesLeases, schedulerScheduler, stagers, stagingPool, targetPool)
 	retryTarget := decorators.ProvideRetryTarget(targetPool)
 	immediateImmediate := immediate.ProvideImmediate(sequencerConfig, targetPool, marker, once, retryTarget, stagers)
-	sequencer := script2.ProvideSequencer(loader, targetPool, watchers)
-	switcherSwitcher := switcher.ProvideSequencer(bestEffort, coreCore, diagnostics, immediateImmediate, sequencer, stagingPool, targetPool)
-	conveyors, err := conveyor.ProvideConveyors(ctx, acceptor, conveyorConfig, checkpoints, retireRetire, switcherSwitcher, watchers)
+	switcherSwitcher := switcher.ProvideSequencer(bestEffort, coreCore, diagnostics, immediateImmediate, stagingPool, targetPool)
+	conveyors, err := conveyor.ProvideConveyors(ctx, acceptor, conveyorConfig, checkpoints, sequencer, retireRetire, switcherSwitcher, watchers)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/source/mylogical/conn.go
+++ b/internal/source/mylogical/conn.go
@@ -386,12 +386,11 @@ func (c *conn) onDataTuple(
 		if err != nil {
 			return err
 		}
-		if operation != deleteMutation {
-			mut.Data, err = json.Marshal(enc)
-			if err != nil {
-				return err
-			}
+		mut.Data, err = json.Marshal(enc)
+		if err != nil {
+			return err
 		}
+		mut.Deletion = operation == deleteMutation
 		mut.Time = hlc.New(c.nextConsistentPoint.AsTime().UnixNano(), 0)
 		script.AddMeta("mylogical", tbl, &mut)
 		if err := batch.Accumulate(tbl, mut); err != nil {

--- a/internal/source/mylogical/conn_test.go
+++ b/internal/source/mylogical/conn_test.go
@@ -204,8 +204,10 @@ func TestOnDataTuple(t *testing.T) {
 			operation: deleteMutation,
 			wantMuts: []types.Mutation{
 				{
-					Key:  json.RawMessage(`[3]`),
-					Time: ts,
+					Data:     json.RawMessage(`{"k":3,"v":2}`),
+					Deletion: true,
+					Key:      json.RawMessage(`[3]`),
+					Time:     ts,
 				},
 			},
 		},

--- a/internal/source/objstore/wire_gen.go
+++ b/internal/source/objstore/wire_gen.go
@@ -89,6 +89,7 @@ func Start(ctx *stopper.Context, config *Config) (*Objstore, error) {
 	if err != nil {
 		return nil, err
 	}
+	sequencer := script2.ProvideSequencer(loader, targetPool, watchers)
 	sequencerConfig := &eagerConfig.Sequencer
 	stagers := stage.ProvideFactory(stagingPool, stagingSchema, ctx)
 	retireRetire := retire.ProvideRetire(sequencerConfig, stagingPool, stagers)
@@ -106,9 +107,8 @@ func Start(ctx *stopper.Context, config *Config) (*Objstore, error) {
 	coreCore := core.ProvideCore(sequencerConfig, typesLeases, schedulerScheduler, stagers, stagingPool, targetPool)
 	retryTarget := decorators.ProvideRetryTarget(targetPool)
 	immediateImmediate := immediate.ProvideImmediate(sequencerConfig, targetPool, marker, once, retryTarget, stagers)
-	sequencer := script2.ProvideSequencer(loader, targetPool, watchers)
-	switcherSwitcher := switcher.ProvideSequencer(bestEffort, coreCore, diagnostics, immediateImmediate, sequencer, stagingPool, targetPool)
-	conveyors, err := conveyor.ProvideConveyors(ctx, acceptor, conveyorConfig, checkpoints, retireRetire, switcherSwitcher, watchers)
+	switcherSwitcher := switcher.ProvideSequencer(bestEffort, coreCore, diagnostics, immediateImmediate, stagingPool, targetPool)
+	conveyors, err := conveyor.ProvideConveyors(ctx, acceptor, conveyorConfig, checkpoints, sequencer, retireRetire, switcherSwitcher, watchers)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/source/pglogical/conn.go
+++ b/internal/source/pglogical/conn.go
@@ -362,13 +362,11 @@ func (c *Conn) decodeMutation(
 	if err != nil {
 		return mut, errors.WithStack(err)
 	}
-	// We don't need the actual column data for delete operations.
-	if !isDelete {
-		mut.Data, err = json.Marshal(enc)
-		if err != nil {
-			return mut, errors.WithStack(err)
-		}
+	mut.Data, err = json.Marshal(enc)
+	if err != nil {
+		return mut, errors.WithStack(err)
 	}
+	mut.Deletion = isDelete
 	return mut, errors.WithStack(err)
 }
 


### PR DESCRIPTION
This change allows Replicator to support use cases where incoming table names
and primary-key structures do not align with the target database schema. This
is of particular utility for migrations into CockroachDB from partitioned or
sharded tables in a replication source. Replicator no longer requires that
incoming table names exist in the target schema.

The existing dispatch() and deletesTo() callbacks are used to support fan-in.
The crux of the implementation change is to split the script-processing path to
apply configureSource() policies before mutations are received by the
underlying sequencer. In the fully-consistent case, dispatch functions are
applied before mutations are staged. The code in script.sourceAcceptor and
script.targetAcceptor is essentially unchanged from the previous
script.acceptor implementation.

In order to allow the deletesTo() callback access to "wide" delete
notifications, such that PostgreSQL REPLICA IDENTITY FULL, might generate, the
core Mutation type gains a Deletion field. Thus, deletions may have an
associated payload body from which PK columns can be extracted once the
deletion has been assigned to a target table. The existing behavior of
converting a key-only deletion to a document is preserved in cases where the
source table name matches a target table name. As a final fallback, the key
array will be presented to the deletesTo() function in a stub document, thus
allowing all deletion types to be dispatched.

The seqtest.Check helper has a scenario for generating mutations for tables
that do not exist in the target database. Similar partition cases are added to
other logical-replication frontends.

The staging package will now persist a mutation's deletion flag in a new table
column. An automatic schema migration is added.

The apply package will prefer to extract the deletion key from the body of a
deletion-type mutation, if possible. Otherwise, it will use the existing
Mutation.Key field.

The switcher sequencer no longer installs the script sequencer on its own in
order to improve testing usability.

The cdc/handler_test.go file is updated to reflect that the dispatch functions
can rewrite a mutation before it is staged.

The logical_test.ts script now strips any incoming _P_ suffix from incoming
table names in order to support partitioned-input tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/973)
<!-- Reviewable:end -->
