### PR TITLE
Add a schema backup/restore mechanism

### DIFF
--- a/internal/sinktest/all/wire_gen.go
+++ b/internal/sinktest/all/wire_gen.go
@@ -71,7 +71,12 @@ func NewFixture(t testing.TB) (*Fixture, error) {
 	if err != nil {
 		return nil, err
 	}
-	watchers, err := schemawatch.ProvideFactory(context, targetPool, diagnostics)
+	memoMemo, err := memo.ProvideMemo(context, stagingPool, stagingSchema)
+	if err != nil {
+		return nil, err
+	}
+	backup := schemawatch.ProvideBackup(memoMemo, stagingPool)
+	watchers, err := schemawatch.ProvideFactory(context, targetPool, diagnostics, backup)
 	if err != nil {
 		return nil, err
 	}
@@ -85,10 +90,6 @@ func NewFixture(t testing.TB) (*Fixture, error) {
 		return nil, err
 	}
 	checkpoints, err := checkpoint.ProvideCheckpoints(context, stagingPool, stagingSchema)
-	if err != nil {
-		return nil, err
-	}
-	memoMemo, err := memo.ProvideMemo(context, stagingPool, stagingSchema)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/source/cdc/server/test_fixture.go
+++ b/internal/source/cdc/server/test_fixture.go
@@ -36,6 +36,7 @@ type testFixture struct {
 	Config        *Config
 	Diagnostics   *diag.Diagnostics
 	Listener      net.Listener
+	Memo          types.Memo
 	StagingPool   *types.StagingPool
 	Server        *stdserver.Server
 	StagingDB     ident.StagingSchema

--- a/internal/source/cdc/test_fixture.go
+++ b/internal/source/cdc/test_fixture.go
@@ -51,7 +51,7 @@ func newTestFixture(*all.Fixture, *Config) (*testFixture, error) {
 		wire.FieldsOf(new(*base.Fixture),
 			"Context", "StagingDB", "StagingPool", "TargetCache", "TargetPool"),
 		wire.FieldsOf(new(*all.Fixture),
-			"Configs", "Fixture", "Stagers"),
+			"Configs", "Fixture", "Stagers", "Memo"),
 		diag.New,
 		leases.Set,
 		checkpoint.Set,

--- a/internal/source/cdc/wire_gen.go
+++ b/internal/source/cdc/wire_gen.go
@@ -49,7 +49,9 @@ func newTestFixture(fixture *all.Fixture, config *Config) (*testFixture, error) 
 	}
 	targetPool := baseFixture.TargetPool
 	diagnostics := diag.New(context)
-	watchers, err := schemawatch.ProvideFactory(context, targetPool, diagnostics)
+	memo := fixture.Memo
+	backup := schemawatch.ProvideBackup(memo, stagingPool)
+	watchers, err := schemawatch.ProvideFactory(context, targetPool, diagnostics, backup)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/source/kafka/wire_gen.go
+++ b/internal/source/kafka/wire_gen.go
@@ -72,7 +72,8 @@ func Start(ctx *stopper.Context, config *Config) (*Kafka, error) {
 		return nil, err
 	}
 	dlqConfig := &eagerConfig.DLQ
-	watchers, err := schemawatch.ProvideFactory(ctx, targetPool, diagnostics)
+	backup := schemawatch.ProvideBackup(memoMemo, stagingPool)
+	watchers, err := schemawatch.ProvideFactory(ctx, targetPool, diagnostics, backup)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/source/mylogical/wire_gen.go
+++ b/internal/source/mylogical/wire_gen.go
@@ -68,7 +68,8 @@ func Start(ctx *stopper.Context, config *Config) (*MYLogical, error) {
 		return nil, err
 	}
 	dlqConfig := &eagerConfig.DLQ
-	watchers, err := schemawatch.ProvideFactory(ctx, targetPool, diagnostics)
+	backup := schemawatch.ProvideBackup(memoMemo, stagingPool)
+	watchers, err := schemawatch.ProvideFactory(ctx, targetPool, diagnostics, backup)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/source/objstore/wire_gen.go
+++ b/internal/source/objstore/wire_gen.go
@@ -71,7 +71,8 @@ func Start(ctx *stopper.Context, config *Config) (*Objstore, error) {
 		return nil, err
 	}
 	dlqConfig := &eagerConfig.DLQ
-	watchers, err := schemawatch.ProvideFactory(ctx, targetPool, diagnostics)
+	backup := schemawatch.ProvideBackup(memoMemo, stagingPool)
+	watchers, err := schemawatch.ProvideFactory(ctx, targetPool, diagnostics, backup)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/source/pglogical/wire_gen.go
+++ b/internal/source/pglogical/wire_gen.go
@@ -68,7 +68,8 @@ func Start(context *stopper.Context, config *Config) (*PGLogical, error) {
 		return nil, err
 	}
 	dlqConfig := &eagerConfig.DLQ
-	watchers, err := schemawatch.ProvideFactory(context, targetPool, diagnostics)
+	backup := schemawatch.ProvideBackup(memoMemo, stagingPool)
+	watchers, err := schemawatch.ProvideFactory(context, targetPool, diagnostics, backup)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/target/schemawatch/backup.go
+++ b/internal/target/schemawatch/backup.go
@@ -1,0 +1,104 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package schemawatch
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/cockroachdb/field-eng-powertools/notify"
+	"github.com/cockroachdb/field-eng-powertools/stopper"
+	"github.com/cockroachdb/field-eng-powertools/stopvar"
+	"github.com/cockroachdb/replicator/internal/types"
+	"github.com/cockroachdb/replicator/internal/util/ident"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// Backup handles schema backups and restores. It allows staging
+// progress when the target database is down.
+type Backup interface {
+	backup(ctx *stopper.Context, schema ident.Schema, data *types.SchemaData) error
+	restore(ctx *stopper.Context, schema ident.Schema) (*types.SchemaData, error)
+	startUpdates(
+		ctx *stopper.Context,
+		schemaVar *notify.Var[*types.SchemaData],
+		schema ident.Schema,
+	)
+}
+
+// memoBackup implements Backup and is backed by the staging table memo
+// store
+type memoBackup struct {
+	memo        types.Memo
+	stagingPool *types.StagingPool
+}
+
+var _ Backup = (*memoBackup)(nil)
+
+// backup backs up a schema
+func (b *memoBackup) backup(
+	ctx *stopper.Context, schema ident.Schema, data *types.SchemaData,
+) error {
+	dataBytes, err := json.Marshal(data)
+	if err != nil {
+		return errors.Wrap(err, "could not marshal schema data")
+	}
+	err = b.memo.Put(ctx, b.stagingPool, b.memoKey(schema), dataBytes)
+	if err != nil {
+		return errors.Wrap(err, "couldn't save schema data")
+	}
+	return nil
+}
+
+// memoKey constructs a key for a schema memo
+func (b *memoBackup) memoKey(schema ident.Schema) string {
+	return fmt.Sprintf("schema-%s", schema.Canonical().Raw())
+}
+
+// restore fetches the latest schema backup
+func (b *memoBackup) restore(ctx *stopper.Context, schema ident.Schema) (*types.SchemaData, error) {
+	schemaBytes, err := b.memo.Get(ctx, b.stagingPool, b.memoKey(schema))
+	if err != nil {
+		return nil, err
+	}
+	data := &types.SchemaData{}
+	err = json.Unmarshal(schemaBytes, data)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// startUpdates watches the supplied schemaVar for changes and updates
+// the backup. It records the initial value of schemaVar as the first "change".
+func (b *memoBackup) startUpdates(
+	ctx *stopper.Context, schemaVar *notify.Var[*types.SchemaData], schema ident.Schema,
+) {
+	// watch schemaVar and write changes as a staging memo
+	ctx.Go(func(ctx *stopper.Context) error {
+		_, err := stopvar.DoWhenChanged(ctx, nil, schemaVar, func(ctx *stopper.Context, _, d *types.SchemaData) error {
+			err := b.backup(ctx, schema, d)
+			if err != nil {
+				// Log the error, but don't exit the loop
+				log.WithError(err).WithField("target", schema).Warn("failed to backup schema data")
+			}
+			return nil
+		})
+		return err
+	})
+}

--- a/internal/target/schemawatch/backup_test.go
+++ b/internal/target/schemawatch/backup_test.go
@@ -1,0 +1,83 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package schemawatch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/field-eng-powertools/notify"
+	"github.com/cockroachdb/field-eng-powertools/stopper"
+	"github.com/cockroachdb/field-eng-powertools/stopvar"
+	"github.com/cockroachdb/replicator/internal/staging/memo"
+	"github.com/cockroachdb/replicator/internal/types"
+	"github.com/cockroachdb/replicator/internal/util/ident"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackup_BackupRestore(t *testing.T) {
+	b := &memoBackup{
+		memo:        &memo.Memory{},
+		stagingPool: nil,
+	}
+
+	schema := ident.MustSchema(ident.New("test"))
+	schemaData := &types.SchemaData{Order: make([][]ident.Table, 3)}
+
+	ctx := stopper.Background()
+	r := require.New(t)
+
+	err := b.backup(ctx, schema, schemaData)
+	r.NoError(err)
+
+	restored, err := b.restore(ctx, schema)
+	r.NoError(err)
+	r.Equal(restored, schemaData)
+}
+
+func TestBackup_Update(t *testing.T) {
+	memory := &memo.Memory{
+		WriteCounter: notify.VarOf(0),
+	}
+	b := &memoBackup{
+		memo:        memory,
+		stagingPool: nil,
+	}
+
+	schema := ident.MustSchema(ident.New("test"))
+	schemaData := &types.SchemaData{Order: make([][]ident.Table, 3)}
+	schemaData2 := &types.SchemaData{Order: make([][]ident.Table, 2)}
+
+	ctx := stopper.WithContext(context.Background())
+	defer ctx.Stop(0)
+	r := require.New(t)
+
+	nv := notify.VarOf(schemaData)
+
+	beforeFirstUpdate, _ := memory.WriteCounter.Get()
+	b.startUpdates(ctx, nv, schema)
+	// startUpdates takes a backup of the initial value
+	afterFirstUpdate, _ := stopvar.WaitForChange(ctx, beforeFirstUpdate, memory.WriteCounter)
+
+	nv.Set(schemaData2)
+	// after the value changes, it takes another backup
+	stopvar.WaitForChange(ctx, afterFirstUpdate, memory.WriteCounter)
+
+	restored, err := b.restore(ctx, schema)
+	r.NoError(err)
+	r.Equal(schemaData2, restored)
+}

--- a/internal/target/schemawatch/factory.go
+++ b/internal/target/schemawatch/factory.go
@@ -28,9 +28,10 @@ import (
 
 // factory is a memoizing factory for watcher instances.
 type factory struct {
-	pool *types.TargetPool
-	stop *stopper.Context
-	mu   struct {
+	backup Backup
+	pool   *types.TargetPool
+	stop   *stopper.Context
+	mu     struct {
 		sync.RWMutex
 		data *ident.SchemaMap[*watcher]
 	}
@@ -72,7 +73,7 @@ func (f *factory) createUnlocked(db ident.Schema) (*watcher, error) {
 		return ret, nil
 	}
 
-	ret, err := newWatcher(f.stop, f.pool, db)
+	ret, err := newWatcher(f.stop, f.pool, db, f.backup)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/target/schemawatch/watcher.go
+++ b/internal/target/schemawatch/watcher.go
@@ -23,6 +23,7 @@ import (
 	"database/sql"
 	"flag"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/cockroachdb/field-eng-powertools/notify"
@@ -53,18 +54,38 @@ var _ types.Watcher = (*watcher)(nil)
 // newWatcher constructs a new watcher to monitor the table schema in the
 // named database. The returned watcher will internally refresh
 // until the cancel callback is executed.
-func newWatcher(ctx *stopper.Context, tx *types.TargetPool, schema ident.Schema) (*watcher, error) {
+func newWatcher(
+	ctx *stopper.Context, tx *types.TargetPool, schema ident.Schema, b Backup,
+) (*watcher, error) {
 	w := &watcher{
 		delay:  *RefreshDelay,
 		schema: schema,
 	}
 
-	// Initial data load to sanity-check and make ready.
-	data, err := w.getTables(ctx, tx)
-	if err != nil {
-		return nil, err
+	var data *types.SchemaData
+	if err := tx.Ping(); err != nil {
+		log.WithError(err).Warn("failed to ping target database; trying to restore backup")
+		// On start up, when the target database is down, fall back to
+		// the staging memo about the table schema
+		data, err = b.restore(ctx, schema)
+		if err != nil {
+			return nil, err
+		}
+		if data == nil {
+			// Restore saw no errors, but we also didn't have a value
+			return nil, errors.Wrapf(err, "no backup schema data for %s", schema)
+		}
+	} else {
+		// Initial data load to sanity-check and make ready.
+		data, err = w.getTables(ctx, tx)
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	w.data = notify.VarOf(data)
+
+	b.startUpdates(ctx, w.data, schema)
 
 	if w.delay > 0 {
 		ctx.Go(func(ctx *stopper.Context) error {
@@ -99,7 +120,10 @@ func (w *watcher) Refresh(ctx context.Context, tx *types.TargetPool) error {
 		return err
 	}
 
-	w.data.Set(next)
+	prev, _ := w.data.Get()
+	if !reflect.DeepEqual(prev, next) {
+		w.data.Set(next)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Store the schema to the staging memo, and restore it when the target database is down on startup.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/980)
<!-- Reviewable:end -->
