### PR TITLE
sequencer: Improve visibility of long-running background tasks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cockroachdb/apd v1.1.0
 	github.com/cockroachdb/crlfmt v0.3.0
 	github.com/cockroachdb/datadriven v1.0.2
-	github.com/cockroachdb/field-eng-powertools v0.1.1
+	github.com/cockroachdb/field-eng-powertools v0.0.0-20240829142217-c680a7021280
 	github.com/dop251/goja v0.0.0-20230919151941-fc55792775de
 	github.com/evanw/esbuild v0.23.1
 	github.com/go-mysql-org/go-mysql v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,10 @@ github.com/cockroachdb/crlfmt v0.3.0 h1:IaPIlidTHn7s493ozBcpnkF/HNzCNe7aBJmUMqgI
 github.com/cockroachdb/crlfmt v0.3.0/go.mod h1:iRZvVcb8vDQK4dh64mPRZBucM85Xd/VLTE0cmO95/Kk=
 github.com/cockroachdb/datadriven v1.0.2 h1:H9MtNqVoVhvd9nCBwOyDjUEdZCREqbIdCJD93PBm/jA=
 github.com/cockroachdb/datadriven v1.0.2/go.mod h1:a9RdTaap04u637JoCzcUoIcDmvwSUtcUFtT/C3kJlTU=
+github.com/cockroachdb/field-eng-powertools v0.0.0-20240828183038-0bbf63872b77 h1:7sffr3Hxd+2uNv1vAbdAgjyD/dXWxSNBBkyDGfE564w=
+github.com/cockroachdb/field-eng-powertools v0.0.0-20240828183038-0bbf63872b77/go.mod h1:DXZPzzi9pGluoaYnp6Nn9So+XGGcvgry8juo6hlfRi8=
+github.com/cockroachdb/field-eng-powertools v0.0.0-20240829142217-c680a7021280 h1:NU+dfZLij19FSZvr3E4MESM168MAvyHSz/UzBKbFc2o=
+github.com/cockroachdb/field-eng-powertools v0.0.0-20240829142217-c680a7021280/go.mod h1:DXZPzzi9pGluoaYnp6Nn9So+XGGcvgry8juo6hlfRi8=
 github.com/cockroachdb/field-eng-powertools v0.1.1 h1:xF8Rb8c9oD55W0BE3yIDWYmF1U2RcV3BJ+pzNEKVpLQ=
 github.com/cockroachdb/field-eng-powertools v0.1.1/go.mod h1:qAoRYmqNSHeI44wOoW4LvXnzRySbB2ocTXpd22OQ5aA=
 github.com/cockroachdb/gostdlib v1.19.0 h1:cSISxkVnTlWhTkyple/T6NXzOi5659FkhxvUgZv+Eb0=

--- a/internal/sequencer/besteffort/best_effort.go
+++ b/internal/sequencer/besteffort/best_effort.go
@@ -84,8 +84,8 @@ func (s *bestEffort) Start(
 	ctx *stopper.Context, opts *sequencer.StartOptions,
 ) (types.MultiAcceptor, *notify.Var[sequencer.Stat], error) {
 	stats := notify.VarOf(sequencer.NewStat(opts.Group, &ident.TableMap[hlc.Range]{}))
-
-	sequtil.LeaseGroup(ctx, s.leases, opts.Group, func(ctx *stopper.Context, group *types.TableGroup) {
+	grace := s.cfg.TaskGracePeriod
+	sequtil.LeaseGroup(ctx, s.leases, grace, opts.Group, func(ctx *stopper.Context, group *types.TableGroup) {
 		for _, table := range opts.Group.Tables {
 			table := table // Capture.
 

--- a/internal/sequencer/core/core.go
+++ b/internal/sequencer/core/core.go
@@ -57,10 +57,10 @@ func (s *Core) Start(
 	ctx *stopper.Context, opts *sequencer.StartOptions,
 ) (types.MultiAcceptor, *notify.Var[sequencer.Stat], error) {
 	progress := notify.VarOf(sequencer.NewStat(opts.Group, &ident.TableMap[hlc.Range]{}))
-
+	grace := s.cfg.TaskGracePeriod
 	// Acquire a lease on the group name to prevent multiple sweepers
 	// from operating.
-	sequtil.LeaseGroup(ctx, s.leases, opts.Group, func(ctx *stopper.Context, group *types.TableGroup) {
+	sequtil.LeaseGroup(ctx, s.leases, grace, opts.Group, func(ctx *stopper.Context, group *types.TableGroup) {
 		// Report which instance of Replicator is processing the tables within the group.
 		activeGauges := make([]prometheus.Gauge, len(group.Tables))
 		for idx, tbl := range group.Tables {

--- a/internal/sequencer/core/round.go
+++ b/internal/sequencer/core/round.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cockroachdb/field-eng-powertools/stopper"
 	"github.com/cockroachdb/replicator/internal/types"
 	"github.com/cockroachdb/replicator/internal/util/hlc"
 	"github.com/cockroachdb/replicator/internal/util/ident"
@@ -78,10 +79,10 @@ func (r *round) accumulate(segment *types.MultiBatch) error {
 
 // scheduleCommit handles the error-retry logic around tryCommit.
 func (r *round) scheduleCommit(
-	ctx context.Context, progressReport chan<- hlc.Range,
+	ctx *stopper.Context, progressReport chan<- hlc.Range,
 ) lockset.Outcome {
 	start := time.Now()
-	return r.Core.scheduler.Batch(r.batch, func() error {
+	work := func(ctx *stopper.Context) error {
 		// We want to close the reporting channel, unless we're asking
 		// to be retried.
 		finalReport := true
@@ -130,6 +131,14 @@ func (r *round) scheduleCommit(
 		// General error case: poison the keys.
 		r.poisoned.MarkPoisoned(r.batch)
 		return err
+	}
+
+	// We want to make this asynchronous work visible to any enclosing
+	// stoppers. This allows other components to be aware of and wait
+	// for background tasks like (relatively) long-running database
+	// queries to complete.
+	return r.Core.scheduler.Batch(r.batch, func() error {
+		return ctx.Call(work)
 	})
 }
 


### PR DESCRIPTION
This change corrects a context-break, where callbacks executed by the key scheduler were executed using a context from the scheduler's workgroup. In cases where the lease loop recycles and the target database is executing slowly, the old queries were not guaranteed to have been canceled when the next iteration of the loop starts.

This commit depends on https://github.com/cockroachdb/field-eng-powertools/pull/4

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/981)
<!-- Reviewable:end -->
