### PR TITLE
sequencer: Improve visibility of long-running background tasks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/IBM/sarama v1.43.2
 	github.com/cockroachdb/apd v1.1.0
 	github.com/cockroachdb/crlfmt v0.1.0
-	github.com/cockroachdb/field-eng-powertools v0.1.1
+	github.com/cockroachdb/field-eng-powertools v0.0.0-20240829142217-c680a7021280
 	github.com/dop251/goja v0.0.0-20230919151941-fc55792775de
 	github.com/evanw/esbuild v0.21.4
 	github.com/go-mysql-org/go-mysql v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cockroachdb/crlfmt v0.1.0 h1:7EDFatPBWGbKrR/PBz+qI9OFSOvZQvq3NsYhEYufpo0=
 github.com/cockroachdb/crlfmt v0.1.0/go.mod h1:qtkxNlt5i3rrdirfJE/bQeW/IeLajKexErv7jEIV+Uc=
+github.com/cockroachdb/field-eng-powertools v0.0.0-20240829142217-c680a7021280 h1:NU+dfZLij19FSZvr3E4MESM168MAvyHSz/UzBKbFc2o=
+github.com/cockroachdb/field-eng-powertools v0.0.0-20240829142217-c680a7021280/go.mod h1:DXZPzzi9pGluoaYnp6Nn9So+XGGcvgry8juo6hlfRi8=
 github.com/cockroachdb/field-eng-powertools v0.1.1 h1:xF8Rb8c9oD55W0BE3yIDWYmF1U2RcV3BJ+pzNEKVpLQ=
 github.com/cockroachdb/field-eng-powertools v0.1.1/go.mod h1:qAoRYmqNSHeI44wOoW4LvXnzRySbB2ocTXpd22OQ5aA=
 github.com/cockroachdb/gostdlib v1.19.0 h1:cSISxkVnTlWhTkyple/T6NXzOi5659FkhxvUgZv+Eb0=

--- a/internal/sequencer/besteffort/best_effort.go
+++ b/internal/sequencer/besteffort/best_effort.go
@@ -81,8 +81,8 @@ func (s *bestEffort) Start(
 	ctx *stopper.Context, opts *sequencer.StartOptions,
 ) (types.MultiAcceptor, *notify.Var[sequencer.Stat], error) {
 	stats := notify.VarOf(sequencer.NewStat(opts.Group, &ident.TableMap[hlc.Range]{}))
-
-	sequtil.LeaseGroup(ctx, s.leases, opts.Group, func(ctx *stopper.Context, group *types.TableGroup) {
+	grace := s.cfg.TaskGracePeriod
+	sequtil.LeaseGroup(ctx, s.leases, grace, opts.Group, func(ctx *stopper.Context, group *types.TableGroup) {
 		for _, table := range opts.Group.Tables {
 			table := table // Capture.
 

--- a/internal/sequencer/config.go
+++ b/internal/sequencer/config.go
@@ -26,6 +26,7 @@ import (
 const (
 	DefaultFlushPeriod     = 1 * time.Second
 	DefaultFlushSize       = 1_000
+	DefaultTaskGracePeriod = time.Minute
 	DefaultParallelism     = 16
 	DefaultQuiescentPeriod = 10 * time.Second
 	DefaultRetireOffset    = 24 * time.Hour
@@ -43,6 +44,7 @@ type Config struct {
 	QuiescentPeriod time.Duration // How often to sweep for queued mutations.
 	RetireOffset    time.Duration // Delay removal of applied mutations.
 	ScanSize        int           // Limit on staging-table read queries.
+	TaskGracePeriod time.Duration // How long to allow previous iteration to clean up.
 	TimestampLimit  int           // The maximum number of timestamps to operate on.
 }
 
@@ -60,6 +62,8 @@ func (c *Config) Bind(flags *pflag.FlagSet) {
 		"delay removal of applied mutations")
 	flags.IntVar(&c.ScanSize, "scanSize", DefaultScanSize,
 		"the number of rows to retrieve from staging")
+	flags.DurationVar(&c.TaskGracePeriod, "taskGracePeriod", DefaultTaskGracePeriod,
+		"how long to allow for task cleanup when recovering from errors")
 	flags.IntVar(&c.TimestampLimit, "timestampLimit", DefaultTimestampLimit,
 		"the maximum number of source timestamps to coalesce into a target transaction")
 }
@@ -84,6 +88,9 @@ func (c *Config) Preflight() error {
 	}
 	if c.ScanSize == 0 {
 		c.ScanSize = DefaultScanSize
+	}
+	if c.TaskGracePeriod <= 0 {
+		c.TaskGracePeriod = DefaultTaskGracePeriod
 	}
 	if c.TimestampLimit <= 0 {
 		c.TimestampLimit = DefaultTimestampLimit

--- a/internal/sequencer/core/core.go
+++ b/internal/sequencer/core/core.go
@@ -57,10 +57,10 @@ func (s *Core) Start(
 	ctx *stopper.Context, opts *sequencer.StartOptions,
 ) (types.MultiAcceptor, *notify.Var[sequencer.Stat], error) {
 	progress := notify.VarOf(sequencer.NewStat(opts.Group, &ident.TableMap[hlc.Range]{}))
-
+	grace := s.cfg.TaskGracePeriod
 	// Acquire a lease on the group name to prevent multiple sweepers
 	// from operating.
-	sequtil.LeaseGroup(ctx, s.leases, opts.Group, func(ctx *stopper.Context, group *types.TableGroup) {
+	sequtil.LeaseGroup(ctx, s.leases, grace, opts.Group, func(ctx *stopper.Context, group *types.TableGroup) {
 		// Report which instance of Replicator is processing the tables within the group.
 		activeGauges := make([]prometheus.Gauge, len(group.Tables))
 		for idx, tbl := range group.Tables {


### PR DESCRIPTION
This change corrects a context-break, where callbacks executed by the key scheduler were executed using a context from the scheduler's workgroup. In cases where the lease loop recycles and the target database is executing slowly, the old queries were not guaranteed to have been canceled when the next iteration of the loop starts.

Replicator will now exit if a stuck task is detected by the lease loop since there is no other way to guarantee that the task would not continue at some arbitrary point in the future.

This commit depends on https://github.com/cockroachdb/field-eng-powertools/pull/4

(cherry picked from commit 644ad7c1b4d004ba7b01bf836138474c2f1867b7)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/982)
<!-- Reviewable:end -->
