### PR TITLE
chaos: Cover each distinct stack trace

### DIFF
--- a/internal/sequencer/chaos/chaos.go
+++ b/internal/sequencer/chaos/chaos.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"errors"
 	"math/rand"
+	"runtime"
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/field-eng-powertools/notify"
@@ -29,12 +31,16 @@ import (
 	"github.com/cockroachdb/replicator/internal/types"
 )
 
+// The number of stack frames to consider when determining unique call
+// sites. This was determined empirically.
+const maxFrames = 25
+
 // ErrChaos can be used in tests to differentiate intentionally injected
 // errors versus unexpected errors.
 var ErrChaos = errors.New("chaos")
 
 // Chaos is a [sequencer.Shim] that randomly injects errors into the
-// acceptor base on [sequencer.StartOptions.Chaos].
+// acceptor based on [sequencer.StartOptions.Chaos].
 type Chaos struct {
 	Config *sequencer.Config
 }
@@ -45,12 +51,12 @@ var _ sequencer.Shim = (*Chaos)(nil)
 func (c *Chaos) Wrap(
 	_ *stopper.Context, delegate sequencer.Sequencer,
 ) (sequencer.Sequencer, error) {
-	return &chaos{delegate: delegate, prob: c.Config.Chaos}, nil
+	return &chaos{count: c.Config.Chaos, delegate: delegate}, nil
 }
 
 type chaos struct {
+	count    int
 	delegate sequencer.Sequencer
-	prob     float32
 }
 
 var _ sequencer.Sequencer = (*chaos)(nil)
@@ -59,15 +65,15 @@ var _ sequencer.Sequencer = (*chaos)(nil)
 func (c *chaos) Start(
 	ctx *stopper.Context, opts *sequencer.StartOptions,
 ) (types.MultiAcceptor, *notify.Var[sequencer.Stat], error) {
-	if c.prob <= 0 {
+	if c.count == 0 {
 		return c.delegate.Start(ctx, opts)
 	}
 	// Inject errors deeper into the stack.
 	opts = opts.Copy()
-	opts.Delegate = &acceptor{delegate: opts.Delegate, prob: c.prob}
+	opts.Delegate = &acceptor{count: c.count, delegate: opts.Delegate}
 	acc, stat, err := c.delegate.Start(ctx, opts)
 	// Inject errors at periphery of stack.
-	return &acceptor{acc, c.prob}, stat, err
+	return &acceptor{count: c.count, delegate: acc}, stat, err
 }
 
 // Unwrap is an informal protocol to access the delegate.
@@ -75,12 +81,16 @@ func (c *chaos) Unwrap() sequencer.Sequencer {
 	return c.delegate
 }
 
-// acceptor will inject [ErrChaos] with the configured probability. If
-// the method call should result in a chaos error, the error may be
+// acceptor will inject [ErrChaos] count times per distinct call stack.
+// If the method call should result in a chaos error, the error may be
 // returned after calling the delegate method.
 type acceptor struct {
+	count    int
 	delegate types.MultiAcceptor
-	prob     float32
+	mu       struct {
+		sync.Mutex
+		seen map[[maxFrames]uintptr]int
+	}
 }
 
 var _ types.MultiAcceptor = (*acceptor)(nil)
@@ -143,10 +153,23 @@ func (a *acceptor) Unwrap() types.MultiAcceptor {
 
 // chaos exists to have an easy place to set a breakpoint.
 func (a *acceptor) chaos() error {
-	if rand.Float32() <= a.prob {
-		return ErrChaos
+	// We ignore Callers(), chaos(), and acceptor method.
+	var stack [maxFrames]uintptr
+	runtime.Callers(3, stack[:])
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.mu.seen == nil {
+		a.mu.seen = make(map[[maxFrames]uintptr]int)
 	}
-	return nil
+
+	count := a.mu.seen[stack]
+	if count >= a.count {
+		return nil
+	}
+	a.mu.seen[stack] = count + 1
+	return ErrChaos
 }
 
 // delay exists to add jitter within the system. It can help shake loose

--- a/internal/sequencer/config.go
+++ b/internal/sequencer/config.go
@@ -40,7 +40,7 @@ const (
 // Config is an injection point common to sequencer implementations. Not
 // all sequencers necessarily respond to all configuration options.
 type Config struct {
-	Chaos            float32       // Set by tests to inject errors.
+	Chaos            int           // Set by tests to inject errors this many times per call site.
 	FlushPeriod      time.Duration // Don't queue mutations for longer than this.
 	FlushSize        int           // Ideal target database transaction size
 	IdempotentSource bool          // The upstream source is idempotent, disable extra marking.

--- a/internal/sequencer/seqtest/check.go
+++ b/internal/sequencer/seqtest/check.go
@@ -157,7 +157,7 @@ api.configureSource("%[1]s", {
 			r.NoError(err)
 		}
 		if flags.Chaos() {
-			cfg.Chaos = 0.001
+			cfg.Chaos = 2
 			seq, err = seqFixture.Chaos.Wrap(ctx, seq)
 			r.NoError(err)
 		}

--- a/internal/source/kafka/integration_test.go
+++ b/internal/source/kafka/integration_test.go
@@ -200,7 +200,7 @@ func getConfig(fixture *base.Fixture, fc *fixtureConfig, tgt ident.Table) (*Conf
 		Topics:           []string{tgt.Raw()},
 	}
 	if fc.chaos {
-		config.Sequencer.Chaos = 0.0005
+		config.Sequencer.Chaos = 2
 	}
 	if fc.script {
 		config.Script = script.Config{

--- a/internal/source/mylogical/integration_test.go
+++ b/internal/source/mylogical/integration_test.go
@@ -512,7 +512,7 @@ func getConfig(fixture *all.Fixture, fc *fixtureConfig, tgt ident.Table) (*Confi
 		TargetSchema: dbName,
 	}
 	if fc.chaos {
-		config.Sequencer.Chaos = 0.0005
+		config.Sequencer.Chaos = 2
 	}
 	if fc.script {
 		config.Script = script.Config{

--- a/internal/source/objstore/integration_test.go
+++ b/internal/source/objstore/integration_test.go
@@ -425,7 +425,7 @@ func getConfig(
 		Workers:      defaultNumberOfWorkers,
 	}
 	if fc.chaos {
-		config.Sequencer.Chaos = 0.005
+		config.Sequencer.Chaos = 2
 	}
 	if fc.script {
 		config.Script = script.Config{

--- a/internal/source/pglogical/integration_test.go
+++ b/internal/source/pglogical/integration_test.go
@@ -216,7 +216,7 @@ func testPGLogical(t *testing.T, fc *fixtureConfig) {
 		TargetSchema:   dbSchema,
 	}
 	if fc.chaos {
-		cfg.Sequencer.Chaos = 0.001
+		cfg.Sequencer.Chaos = 2
 	}
 	if fc.script {
 		cfg.Script = script.Config{


### PR DESCRIPTION
The chaos shim currently returns ErrChaos based on a probability. It has proven difficult to choose probabilities that are guaranteed to test all error-return paths but that don't slow testing arbitrarily. This change makes the chaos acceptor return an error a defined number of times per unique stack trace.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/989)
<!-- Reviewable:end -->
