### PR TITLE
checkpoint: Rework limited checkpoint scan query

### DIFF
--- a/internal/staging/checkpoint/checkpoint.go
+++ b/internal/staging/checkpoint/checkpoint.go
@@ -87,7 +87,9 @@ func (r *Checkpoints) newGroup(
 
 	var limit string
 	if lookahead > 0 {
-		limit = fmt.Sprintf("ORDER BY source_hlc LIMIT %d", lookahead)
+		// +1 to have a window that includes both the last applied
+		// checkpoint and the next unapplied checkpoint.
+		limit = fmt.Sprintf("WHERE r <= %d", lookahead+1)
 	}
 	// This query may indeed require a full table scan.
 	ret.sql.refresh = fmt.Sprintf(refreshTemplate, r.metaTable, limit)


### PR DESCRIPTION
The previous iteration of this query did not correctly handle operating on an existing checkpoint table. The applied limit would prevent the query from scanning ahead to actually find new work to do. This change reworks the query to progressively narrow the range of timestamps for each checkpoint partition before applying the limit. The test is also updated to ensure that the restart case is correctly handled.

Unchanged pick from PR #985

(cherry picked from commit 10a545aeb69fe3d2f38e0f69ec46fa19d646398d)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/990)
<!-- Reviewable:end -->
