### PR TITLE
schemawatch: Extract table dependency information from target

### DIFF
--- a/internal/target/schemawatch/coldata.go
+++ b/internal/target/schemawatch/coldata.go
@@ -224,6 +224,10 @@ ORDER BY ordered.ordinal_position, column_name
 //
 // See also:
 // https://docs.oracle.com/en/database/oracle/oracle-database/19/refrn/ALL_TAB_COLS.html
+//
+// The gather_plan_statistics hint appears to enable some adaptive
+// optimizer choices that significantly increase the performance of this
+// query.
 const sqlColumnsQueryOra = `
 WITH atc AS (
   SELECT OWNER, TABLE_NAME, COLUMN_NAME,
@@ -245,7 +249,8 @@ WITH atc AS (
 ),
      pk_cols  AS (SELECT OWNER, TABLE_NAME, CONSTRAINT_NAME FROM ALL_CONSTRAINTS WHERE CONSTRAINT_TYPE='P'),
      acc AS (SELECT OWNER, TABLE_NAME, COLUMN_NAME, CONSTRAINT_NAME, POSITION, 't' IS_PK FROM ALL_CONS_COLUMNS)
-SELECT COLUMN_NAME,
+SELECT /*+  gather_plan_statistics */
+       COLUMN_NAME,
        COALESCE(IS_PK, 'f'),
        atc.DATA_TYPE,
        atc.DATA_DEFAULT,

--- a/internal/target/schemawatch/coldata_test.go
+++ b/internal/target/schemawatch/coldata_test.go
@@ -557,9 +557,7 @@ func TestColDataIgnoresViews(t *testing.T) {
 	a.False(ok)
 	a.Nil(viewData)
 
-	for _, level := range schemaData.Order {
-		for _, entry := range level {
-			a.False(ident.Equal(viewName, entry), "should not find view in Order")
-		}
+	for _, table := range schemaData.Entire.Order {
+		a.False(ident.Equal(viewName, table), "should not find view in Order")
 	}
 }

--- a/internal/target/schemawatch/dependencies.go
+++ b/internal/target/schemawatch/dependencies.go
@@ -24,292 +24,206 @@ import (
 	"github.com/cockroachdb/replicator/internal/types"
 	"github.com/cockroachdb/replicator/internal/util/ident"
 	"github.com/cockroachdb/replicator/internal/util/retry"
+	"github.com/cockroachdb/replicator/internal/util/stdpool"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
-// depOrderTemplateMySQL computes the "referential depth" of tables based on
-// foreign-key constraints.
+// depOrderTemplateMySQL creates a mapping of child to parent tables.
 //
-// The query is structured as follows:
-//   - tables: Tables in the schema.
-//   - refs: Maps referring tables (child) to referenced tables
-//     (parent). Table self-references are excluded from this query.
-//   - roots: Tables with no FK references.
-//   - depths: Recursively computes the depth of each table from the root, walking
-//     the foreign keys constraints.
-//   - cycle_detect: ensure that all tables have a depth, by injecting a default depth.
-//     Finally, compute the maximum depth for each table in the given schema.
-
+// - $1: Table catalog (always "def" in MySQL)
+// - $2: Table schema ("my_database")
+//
+// CTE elements:
+//   - q: The catalog and schema to query
+//   - tables: All base tables in the target schema
+//   - refs: Creates child to parent mappings. In information_schema, an
+//     FK reference is expressed as a constraint applied to some (child)
+//     table that references a unique constraint on another (parent)
+//     table.
+//   - seeds: Emits a dummy row for all tables in the schema. This
+//     ensures that tables with no children are still in the result set.
+//   - top level: Union of refs and seeds
 const depOrderTemplateMySQL = `
-WITH RECURSIVE
-  tables
-    AS (
-      SELECT
-        table_catalog, table_schema, table_name
-      FROM
-        information_schema.tables
-      WHERE table_type = 'BASE TABLE'
-    ),
-  refs
-    AS (
-        SELECT
-            constraint_catalog AS child_catalog,
-            constraint_schema AS child_schema,
-            table_name AS child_table_name,
-            unique_constraint_catalog AS parent_catalog,
-            unique_constraint_schema AS parent_schema,
-            referenced_table_name AS parent_table_name
-            FROM information_schema.referential_constraints
-       WHERE
-        (constraint_catalog, constraint_schema, table_name)
-        != (unique_constraint_catalog, unique_constraint_schema,referenced_table_name)
-    ),
-  roots
-    AS (
-      SELECT
-        tables.table_catalog, tables.table_schema, tables.table_name
-      FROM
-        tables
-      WHERE
-        (tables.table_catalog, tables.table_schema, tables.table_name)
-        NOT IN (SELECT child_catalog, child_schema, child_table_name FROM refs)
-    ),
-  depths
-    AS (
-      SELECT table_catalog, table_schema, table_name, 0 AS depth FROM roots
-      UNION ALL
-        SELECT
-          refs.child_catalog,
-          refs.child_schema,
-          refs.child_table_name,
-          depths.depth + 1
-        FROM
-          depths, refs
-        WHERE
-          refs.parent_catalog = depths.table_catalog
-          AND refs.parent_schema = depths.table_schema
-          AND refs.parent_table_name = depths.table_name
-    ),
-  cycle_detect
-    AS (
-      SELECT table_catalog, table_schema, table_name, -1 AS depth FROM tables
-      UNION ALL
-        SELECT table_catalog, table_schema, table_name, depth FROM depths
-    )
-SELECT
-  table_name, max(depth) AS depth
-FROM
-  cycle_detect
-WHERE
-   table_schema = ?
-GROUP BY
-  table_name
-ORDER BY
-  depth, table_name`
+WITH
+ q (table_catalog, table_schema) AS (SELECT ?, ?),
+ tables
+  AS (
+   SELECT
+    table_catalog, table_schema, table_name
+   FROM
+    information_schema.tables JOIN q USING (table_catalog, table_schema)
+   WHERE
+    table_type = 'BASE TABLE'
+  ),
+ refs
+  AS (
+   SELECT
+    constraint_catalog AS child_catalog,
+    constraint_schema AS child_schema,
+    table_name AS child_table_name,
+    unique_constraint_catalog AS parent_catalog,
+    unique_constraint_schema AS parent_schema,
+    referenced_table_name AS parent_table_name
+   FROM
+    information_schema.referential_constraints AS r
+    JOIN q ON
+      r.unique_constraint_catalog = q.table_catalog
+      AND (
+        r.unique_constraint_schema = q.table_schema
+        OR r.constraint_schema = q.table_schema
+       )
+   WHERE
+    (constraint_schema, table_name) != (unique_constraint_schema, referenced_table_name)
+  ),
+ seeds
+  AS (
+   SELECT
+    NULL AS child_catalog,
+    NULL AS child_schema,
+    NULL AS child_table_name,
+    table_catalog AS parent_catalog,
+    table_schema AS parent_schema,
+    table_name AS parent_table_name
+   FROM
+    tables
+  )
+SELECT * FROM seeds
+UNION ALL
+SELECT * FROM refs
+`
 
-// depOrderTemplateOra computes the "referential depth" of tables based on
-// foreign-key constraints.
+// depOrderTemplateOra creates a mapping of child to parent tables.
+//
+// - owner: The owner of the tables to query ("my_application")
 //
 // The query is structured as follows:
+//   - q: The schema to query.
 //   - parent_refs: Identifies all index References as a mapping of
 //     (owner, table) -> (owner, constraint).
 //   - ref_to_tbl: Resolves the constraint name references to Primary or
 //     Unique indexes to parent table names.
 //   - tbl_to_parent: Joins parent_refs and ref_to_tbl to produce
 //     child(owner, table) -> parent(owner, table) mappings.
-//   - root: Any table that is not referenced in tbl_to_parent. Contains
-//     extra columns to be column-compatible with tbl_to_parent.
-//   - combo: A union of root and tbl_to_parent. This serves as the
-//     source of data for the recursive query.
-//   - levels: A recursive query that computes the level by finding the
-//     child tables of the previous level. The START WITH clause selects
-//     tables which have no parent or which are self-referential.
-//   - cyclic: Adds a dummy level for every table to detect any cyclic
-//     structures which were excluded by levels.
-//   - The top-level query finds the maximum depth for each table.  We
-//     subtract one from the magic LEVEL value to align with the PG query
-//     below.
+//   - seeds: Emits a dummy row for all tables in the schema. This
+//     ensures that tables with no children are still in the result set.
+//   - top-level: A union of seeds and tbl_to_parent.
+//
+// The gather_plan_statistics hint appears to enable some adaptive
+// optimizer choices that significantly increase the performance of this
+// query.
 const depOrderTemplateOra = `
-WITH parent_refs AS (SELECT OWNER tbl_owner, TABLE_NAME tbl_name, R_OWNER parent_owner, R_CONSTRAINT_NAME ref_name
-                     FROM ALL_CONSTRAINTS
-                     WHERE CONSTRAINT_TYPE = 'R'),
-     ref_to_tbl AS (SELECT CONSTRAINT_NAME ref_name, OWNER parent_owner, TABLE_NAME parent_name
-                    FROM ALL_CONSTRAINTS
-                    WHERE CONSTRAINT_TYPE IN ('P', 'U')),
-     tbl_to_parent AS (SELECT tbl_owner, tbl_name, parent_owner, parent_name
-                       FROM parent_refs
-                       JOIN ref_to_tbl USING (parent_owner, ref_name)),
-     roots AS (SELECT OWNER tbl_owner, TABLE_NAME tbl_name, NULL parent_owner, NULL parent_name
-               FROM ALL_TABLES
-               WHERE (OWNER, TABLE_NAME) NOT IN (SELECT tbl_owner, tbl_name FROM tbl_to_parent)),
-     combo AS (SELECT * FROM roots UNION ALL SELECT * from tbl_to_parent),
-     levels AS (SELECT LEVEL lvl, tbl_owner, tbl_name, parent_owner, parent_name
-                FROM combo
-                START WITH (parent_owner IS NULL AND parent_name IS NULL)
-                        OR (tbl_owner = parent_owner AND tbl_name = parent_name)
-                CONNECT BY NOCYCLE (parent_owner, parent_name) = ((PRIOR tbl_owner, PRIOR tbl_name))),
-     cyclic AS (SELECT 0 lvl, OWNER tbl_owner, TABLE_NAME tbl_name
-                FROM ALL_TABLES
-                UNION ALL
-                SELECT lvl, tbl_owner, tbl_name
-                FROM levels)
-SELECT tbl_name, max(lvl) - 1 lvl
-FROM cyclic
-WHERE tbl_owner = (:owner)
-GROUP BY tbl_name
-ORDER BY lvl, tbl_name`
+WITH
+parent_refs AS (
+    SELECT OWNER child_owner, TABLE_NAME child_name, R_OWNER parent_owner, R_CONSTRAINT_NAME ref_name
+    FROM ALL_CONSTRAINTS
+    WHERE OWNER = :owner AND CONSTRAINT_TYPE = 'R'),
+ref_to_tbl AS (
+    SELECT CONSTRAINT_NAME ref_name, OWNER parent_owner, TABLE_NAME parent_name
+    FROM ALL_CONSTRAINTS
+    WHERE OWNER = :owner AND CONSTRAINT_TYPE IN ('P', 'U')),
+tbl_to_parent AS (
+    SELECT NULL child_cat, child_owner, child_name, '' parent_cat, parent_owner, parent_name
+    FROM ref_to_tbl
+    JOIN parent_refs USING (parent_owner, ref_name)
+    WHERE child_name != parent_name),
+seeds AS (
+    SELECT NULL child_cat, NULL child_owner, NULL child_name, '' parent_cat, OWNER parent_owner, TABLE_NAME parent_name
+    FROM ALL_TABLES
+    WHERE OWNER = :owner)
+SELECT /*+  gather_plan_statistics */ * FROM seeds
+UNION ALL
+SELECT * from tbl_to_parent
+`
 
-// depOrderTemplateCRDB uses the SHOW TABLES porcelain to calculate the referential depth.
-// Older version of CRDB (<= 21.2) experience an infinite loop when executing
-// depOrderTemplatePg.
-const depOrderTemplateCRDB = `
-WITH RECURSIVE
- tables AS (
-   SELECT schema_name AS sch, table_name AS tbl
-   FROM [SHOW TABLES FROM %[1]s]
-   WHERE type='table'),
- refs AS (
-   SELECT
-    constraint_schema AS child_sch, table_name AS child_tbl, referenced_table_name AS parent_tbl
-   FROM %[2]s.information_schema.referential_constraints
-   WHERE table_name != referenced_table_name
- ),
- roots AS (
-   SELECT tables.sch, tables.tbl, 0 AS depth
-   FROM tables
-   WHERE (tables.sch, tables.tbl) NOT IN (SELECT (child_sch, child_tbl) FROM refs)
- ),
- depths AS (
-   SELECT * FROM roots
-   UNION ALL
-    SELECT refs.child_sch, refs.child_tbl, max(depths.depth) + 1
-    FROM depths, refs
-    WHERE refs.parent_tbl = depths.tbl
-    GROUP BY 1, 2
- )
-SELECT tbl, max(depth)
-FROM (SELECT *, -1 AS depth FROM tables UNION ALL SELECT * FROM depths)
-GROUP BY 1
-ORDER BY 2, 1`
-
-// depOrderTemplatePg computes the "referential depth" of tables based on
-// foreign-key constraints. Note that this only works with acyclic FK
-// dependency graphs. This is ok because CRDB's lack of deferrable
-// constraints means that a cyclic dependency graph would be unusable.
-// Once CRDB has deferrable constraints, the need for computing this
-// dependency ordering goes away.
+// depOrderTemplatePg creates a mapping of child to parent tables.
 //
-// The query is structured as follows:
-//   - constraints: Used to resolve constraint names (i.e. primary or
-//     unique indexes) to the table that defines them.
-//   - tables: A list of all tables in the db.
-//   - refs: Maps referring tables (child) to referenced tables
-//     (parent). Table self-references are excluded from this query.
-//   - roots: Tables that contain no FK references to ensure that
-//     cyclical references remain unprocessed.
-//   - depths: A recursive CTE that builds up from the roots. In each
-//     step of the recursion, we select the child tables of the previous
-//     iteration whose parent table has a known depth and use the maximum
-//     parent's depth to derive the child's (updated) depth. The recursion
-//     halts when the previous iteration contains only leaf tables.
-//   - cycle_detect: Adds a sentinel depth value (-1) for all tables.
-//   - The top-level query then finds the maximum depth for each table.
-//     Any tables for which a depth cannot be computed (e.g. cyclical
-//     references) will return the sentinel value from cycle_detect.
+// - $1: Target table catalog ("my_database")
+// - $2: Target table schema ("public")
+// - $3: Boolean to enable <= v23.1 hack; see below.
 //
-// One limitation in this query is that the information_schema doesn't
-// appear to provide any way to know about the schema in which the
-// referenced table is defined.
+// CTE elements:
+//   - q: The catalog and schema to query
+//   - constraints: Associates constraint ids with tables ids
+//   - all_refs: Creates parent-child table name mappings. In
+//     information_schema, an FK reference is expressed as a constraint
+//     applied to some (child) table that references a unique constraint
+//     on another (parent) table. This clause also filters out any
+//     table self-references.
+//   - refs: A recursive clause that chases parents to children,
+//     potentially across schema boundaries. It starts by joining against
+//     q and then fills in any child tables as needed.
+//   - seeds: Emits a dummy row for all tables in the schema. This
+//     ensures that tables with no children are still in the result set.
+//   - top level: Union of refs and seeds.
+//
+// There's a hack for legacy versions of CRDB <= 23.1 which report an
+// incorrect unique_constraint_schema. Cross-schema FK references should
+// be relatively rare, and the FK constraint name can be made unique if
+// required. https://github.com/cockroachdb/cockroach/issues/111419
 const depOrderTemplatePg = `
 WITH RECURSIVE
+  q (table_catalog, table_schema) AS (VALUES ($1::TEXT, $2::TEXT)),
   constraints
     AS (
-      SELECT
-        table_catalog, table_schema, table_name, constraint_name
-      FROM
-        %[1]s.information_schema.table_constraints
+      SELECT table_catalog, table_schema, table_name,
+             constraint_catalog, constraint_schema, constraint_name
+      FROM %[1]s.information_schema.table_constraints
     ),
-  tables
+  all_refs
     AS (
       SELECT
-        table_catalog, table_schema, table_name
-      FROM
-        %[1]s.information_schema.tables
-      WHERE
-        table_type = 'BASE TABLE'
-    ),
-  refs
-    AS (
-      SELECT
-        ref.constraint_catalog AS child_catalog,
-        ref.constraint_schema AS child_schema,
+        child.table_catalog AS child_catalog,
+        child.table_schema AS child_schema,
         child.table_name AS child_table_name,
-        ref.unique_constraint_catalog AS parent_catalog,
-        ref.unique_constraint_schema AS parent_schema,
+        parent.table_catalog AS parent_catalog,
+        parent.table_schema AS parent_schema,
         parent.table_name AS parent_table_name
       FROM
         %[1]s.information_schema.referential_constraints AS ref
         JOIN constraints AS child ON
-            ref.constraint_catalog = child.table_catalog
-            AND ref.constraint_schema = child.table_schema
+            ref.constraint_catalog = child.constraint_catalog
+            AND ref.constraint_schema = child.constraint_schema
             AND ref.constraint_name = child.constraint_name
         JOIN constraints AS parent ON
             ref.unique_constraint_catalog = parent.table_catalog
-            AND ref.unique_constraint_schema = parent.table_schema
+            AND (CASE WHEN $3::BOOLEAN THEN
+                   ref.unique_constraint_schema = child.table_schema
+                ELSE
+                   ref.unique_constraint_schema = parent.table_schema
+                END)
             AND ref.unique_constraint_name = parent.constraint_name
       WHERE
         (child.table_catalog, child.table_schema, child.table_name)
-        != (parent.table_catalog, parent.table_schema, parent.table_name)
-    ),
-  roots
+        != (parent.table_catalog, parent.table_schema, parent.table_name)),
+  refs AS (
+    SELECT ar.* FROM all_refs ar
+    JOIN q ON (ar.parent_catalog, ar.parent_schema) =
+              (q.table_catalog, q.table_schema)
+    UNION
+    SELECT ar.* FROM all_refs ar
+    JOIN refs r ON (ar.parent_catalog, ar.parent_schema, ar.parent_table_name) =
+                   (r.child_catalog, r.child_schema, r.child_table_name)
+   ),
+  seeds
     AS (
       SELECT
-        tables.table_catalog, tables.table_schema, tables.table_name
-      FROM
-        tables
-      WHERE
-        (tables.table_catalog, tables.table_schema, tables.table_name)
-        NOT IN (SELECT child_catalog, child_schema, child_table_name FROM refs)
-    ),
-  depths
-    AS (
-      SELECT table_catalog, table_schema, table_name, 0 AS depth FROM roots
-      UNION ALL
-        SELECT
-          refs.child_catalog,
-          refs.child_schema,
-          refs.child_table_name,
-          depths.depth + 1
-        FROM
-          depths, refs
-        WHERE
-          refs.parent_catalog = depths.table_catalog
-          AND refs.parent_schema = depths.table_schema
-          AND refs.parent_table_name = depths.table_name
-    ),
-  cycle_detect
-    AS (
-      SELECT table_catalog, table_schema, table_name, -1 AS depth FROM tables
-      UNION ALL
-        SELECT table_catalog, table_schema, table_name, depth FROM depths
+        NULL child_catalog, NULL child_schema, NULL child_table_name,
+        table_catalog, table_schema, table_name
+      FROM %[1]s.information_schema.tables t
+      JOIN q USING (table_catalog, table_schema)
+      WHERE table_type = 'BASE TABLE'
     )
-SELECT
-  table_name, max(depth) AS depth
-FROM
-  cycle_detect
-WHERE
-  table_catalog = $1 AND table_schema = $2
-GROUP BY
-  table_name
-ORDER BY
-  depth, table_name`
+SELECT * FROM refs UNION ALL SELECT * FROM seeds
+`
 
-// getDependencyOrder returns equivalency groups of tables defined
-// within the given database. The order of the slice will satisfy
-// the (acyclic) foreign-key dependency graph.
-func getDependencyOrder(
+// getDependencyRefs returns a map describing the parent-to-children
+// relationships of tables. That is, the map values are the tables that
+// have some immediate dependency on the key. Tables with no
+// dependencies will have a zero-length slice as the value.
+func getDependencyRefs(
 	ctx context.Context, tx *types.TargetPool, db ident.Schema,
-) ([][]ident.Table, error) {
+) (*ident.TableMap[[]ident.Table], error) {
 	var args []any
 	var stmt string
 	switch tx.Product {
@@ -320,19 +234,18 @@ func getDependencyOrder(
 			return nil, errors.Errorf("expecting two schema parts, had %d", len(parts))
 		}
 
-		// We are using a different template for CRDB
-		// Older release (<= 21.2) may experience infinite loops using
-		// More recent releases may fail to report a correct depth
-		// when there are cross-schema dependencies.
-		// See https://github.com/cockroachdb/cockroach/issues/111419
-		// Once the issue above is fixed and we are not supporting 21.2
-		// we can use depOrderTemplatePg for CRDB as well.
+		// See discussion on depOrderTemplatePg.
+		legacyHack := false
 		if tx.Product == types.ProductCockroachDB {
-			stmt = fmt.Sprintf(depOrderTemplateCRDB, db, parts[0])
-		} else {
-			stmt = fmt.Sprintf(depOrderTemplatePg, parts[0])
-			args = []any{parts[0].Raw(), parts[1].Raw()}
+			modern, err := stdpool.CockroachMinVersion(tx.Version, "v23.2.0")
+			if err != nil {
+				return nil, err
+			}
+			legacyHack = !modern
 		}
+
+		stmt = fmt.Sprintf(depOrderTemplatePg, parts[0])
+		args = []any{parts[0].Raw(), parts[1].Raw(), legacyHack}
 
 	case types.ProductMariaDB, types.ProductMySQL:
 		parts := db.Idents(make([]ident.Ident, 0, 1))
@@ -340,7 +253,8 @@ func getDependencyOrder(
 			return nil, errors.Errorf("expecting one schema parts, had %d", len(parts))
 		}
 		stmt = depOrderTemplateMySQL
-		args = []any{parts[0].Raw()}
+		// Catalog names are hardcoded to "def" in MySQL.
+		args = []any{`def`, parts[0].Raw()}
 
 	case types.ProductOracle:
 		stmt = depOrderTemplateOra
@@ -349,46 +263,78 @@ func getDependencyOrder(
 		return nil, errors.Errorf("getDependencyOrder unimplemented product: %s", tx.Product)
 	}
 
-	var cycles []ident.Table
-	var depOrder [][]ident.Table
+	var ret *ident.TableMap[[]ident.Table]
 	err := retry.Retry(ctx, tx, func(ctx context.Context) error {
+		ret = &ident.TableMap[[]ident.Table]{}
 		rows, err := tx.QueryContext(ctx, stmt, args...)
 		if err != nil {
 			return errors.Wrap(err, stmt)
 		}
-		defer rows.Close()
+		defer func() { _ = rows.Close() }()
 
-		currentOrder := -1
+		// We have a switch statement here since PG-style databases have
+		// an extra level in the namespace. Tables with no incoming
+		// dependencies will have a single row with a NULL child table.
 		for rows.Next() {
-			var tableName string
-			var nextOrder int
+			var childDBRaw, childSchemaRaw, childTableRaw sql.NullString
+			var parentDBRaw, parentSchemaRaw, parentTableRaw string
 
-			if err := rows.Scan(&tableName, &nextOrder); err != nil {
-				return err
+			if err := rows.Scan(&childDBRaw, &childSchemaRaw, &childTableRaw,
+				&parentDBRaw, &parentSchemaRaw, &parentTableRaw); err != nil {
+				return errors.WithStack(err)
 			}
 
-			tbl := ident.NewTable(db, ident.New(tableName))
+			var childSchema, parentSchema ident.Schema
+			var childTableName, parentTableName ident.Ident
+			switch tx.Product {
+			case types.ProductCockroachDB, types.ProductPostgreSQL:
+				parentSchema, err = ident.NewSchema(ident.New(parentDBRaw), ident.New(parentSchemaRaw))
+				if err != nil {
+					return err
+				}
+				parentTableName = ident.New(parentTableRaw)
 
-			// Table has no well-defined ordering.
-			if nextOrder < 0 {
-				cycles = append(cycles, tbl)
-				continue
+				if childDBRaw.Valid && childSchemaRaw.Valid && childTableRaw.Valid {
+					childSchema, err = ident.NewSchema(ident.New(childDBRaw.String), ident.New(childSchemaRaw.String))
+					if err != nil {
+						return err
+					}
+					childTableName = ident.New(childTableRaw.String)
+				}
+
+			default:
+				parentSchema, err = ident.NewSchema(ident.New(parentSchemaRaw))
+				if err != nil {
+					return err
+				}
+				parentTableName = ident.New(parentTableRaw)
+
+				if childSchemaRaw.Valid && childTableRaw.Valid {
+					childSchema, err = ident.NewSchema(ident.New(childSchemaRaw.String))
+					if err != nil {
+						return err
+					}
+					childTableName = ident.New(childTableRaw.String)
+				}
 			}
 
-			// Allow skipping a level. This might happen if there
-			// are references across schemas.
-			for nextOrder > currentOrder {
-				depOrder = append(depOrder, nil)
-				currentOrder++
+			parentTable := ident.NewTable(parentSchema, parentTableName)
+			if parentTable.Empty() {
+				// Sanity-check, this should not happen.
+				return errors.New("created an empty parent table")
 			}
-			depOrder[currentOrder] = append(depOrder[currentOrder], tbl)
+
+			// We want to ensure that root tables have an entry, even if
+			// it's zero-length.
+			children := ret.GetZero(parentTable)
+			if !childSchema.Empty() && !childTableName.Empty() {
+				childTable := ident.NewTable(childSchema, childTableName)
+				children = append(children, childTable)
+				log.Tracef("schema query: parent %s -> child %s", parentTable, childTable)
+			}
+			ret.Put(parentTable, children)
 		}
-		return nil
+		return errors.WithStack(rows.Err())
 	})
-
-	if len(cycles) > 0 {
-		return nil, errors.Errorf("cyclical FK references involving tables %s", cycles)
-	}
-
-	return depOrder, err
+	return ret, err
 }

--- a/internal/target/schemawatch/dependencies_test.go
+++ b/internal/target/schemawatch/dependencies_test.go
@@ -14,136 +14,145 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package schemawatch_test
+package schemawatch
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
-	"github.com/cockroachdb/replicator/internal/sinktest/all"
 	"github.com/cockroachdb/replicator/internal/sinktest/base"
 	"github.com/cockroachdb/replicator/internal/types"
-	"github.com/cockroachdb/replicator/internal/util/cmap"
 	"github.com/cockroachdb/replicator/internal/util/ident"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetDependencyOrder(t *testing.T) {
+func TestMain(m *testing.M) {
+	log.SetLevel(log.TraceLevel)
+	os.Exit(m.Run())
+}
+
+// TestGetDependencyRefs validates the query used to extract table
+// relationship information.
+//
+// See also [types.SchemaData] for how this data is consumed.
+func TestGetDependencyRefs(t *testing.T) {
 	a := assert.New(t)
 	r := require.New(t)
 
-	fixture, err := all.NewFixture(t)
+	fixture, err := base.NewFixture(t)
 	r.NoError(err)
 
 	tcs := []struct {
-		name   string
-		order  int
-		schema string
+		name             string
+		schema           string
+		expectedChildren []string
 	}{
 		{
 			"parent",
-			0,
 			"create table %[1]s.parent (pk int primary key)",
+			[]string{"child", "child_2", "three", "four", "five", "six"},
 		},
 		{
-			"parent_2",
-			0,
-			"create table %[1]s.parent_2 (pk int primary key)",
+			"another_table",
+			"create table %[1]s.another_table (pk int primary key)",
+			[]string{},
 		},
 		{
 			"unreferenced",
-			0,
 			"create table %[1]s.unreferenced (pk int primary key)",
+			[]string{},
 		},
 		{
 			"child",
-			1,
 			"create table %[1]s.child (pk int primary key, parent int, foreign key(parent) references %[1]s.parent(pk))",
+			[]string{"grandchild", "grandchild_multi"},
 		},
 		{
 			"child_2",
-			1,
 			"create table %[1]s.child_2 (pk int primary key, parent_2 int, foreign key(parent_2) references %[1]s.parent(pk))",
+			[]string{"grandchild_2", "grandchild_multi"},
 		},
 		{
 			"grandchild",
-			2,
 			"create table %[1]s.grandchild (pk int primary key, child int, foreign key(child) references %[1]s.child(pk))",
+			[]string{"three"},
 		},
 		{
 			"grandchild_2",
-			2,
 			"create table %[1]s.grandchild_2 (pk int primary key, child_2 int, foreign key(child_2) references %[1]s.child_2(pk))",
+			[]string{},
 		},
 		{
 			"grandchild_multi",
-			2,
 			"create table %[1]s.grandchild_multi (pk int primary key, child int, child_2 int, foreign key(child) references %[1]s.child(pk), foreign key(child_2) references %[1]s.child_2(pk))",
+			[]string{},
 		},
 		{
 			"three",
-			3,
 			"create table %[1]s.three (pk int primary key, parent int, gc int,  foreign key(parent) references %[1]s.parent(pk),foreign key(gc) references %[1]s.grandchild(pk))",
+			[]string{"four"},
 		},
 		{
 			"four",
-			4,
 			"create table %[1]s.four (pk int primary key, parent int, other int,  foreign key(parent) references %[1]s.parent(pk), foreign key(other) references %[1]s.three(pk))",
+			[]string{"five"},
 		},
 		{
 			"five",
-			5,
 			"create table %[1]s.five (pk int primary key, parent int, other int, foreign key(parent) references %[1]s.parent(pk), foreign key(other) references %[1]s.four(pk))",
+			[]string{"six"},
 		},
 		{
 			"six",
-			6,
 			"create table %[1]s.six (pk int primary key, parent int, other int,  foreign key(parent) references %[1]s.parent(pk), foreign key(other) references %[1]s.five(pk))",
+			[]string{},
 		},
 		// Verify that a self-referential table returns reasonable values.
 		{
 			"self",
-			0,
 			"create table %[1]s.self (pk int primary key, this int,  foreign key(this) references %[1]s.self(pk))",
+			[]string{"self_child"},
 		},
 		{
 			"self_child",
-			1,
 			"create table %[1]s.self_child (pk int primary key, parent int,  this int, foreign key(parent) references %[1]s.self(pk), foreign key(this) references %[1]s.self_child(pk))",
+			[]string{},
 		},
-	}
-	expected := &ident.Map[int]{}
-	for _, tc := range tcs {
-		expected.Put(ident.New(tc.name), tc.order)
 	}
 
 	ctx := fixture.Context
 	pool := fixture.TargetPool
+	schema := fixture.TargetSchema.Schema()
 
 	for idx, tc := range tcs {
-		sql := fmt.Sprintf(tc.schema, fixture.TargetSchema.Schema())
+		sql := fmt.Sprintf(tc.schema, schema)
 		log.Trace(sql)
 		_, err := pool.ExecContext(ctx, sql)
 		r.NoError(err, idx)
 	}
+	log.Info("finished creating tables")
 
-	r.NoError(fixture.Watcher.Refresh(ctx, pool))
-	snap := fixture.Watcher.Get()
+	refs, err := getDependencyRefs(ctx, pool, schema)
+	r.NoError(err)
 
-	tableCount := 0
-	found := &ident.Map[int]{}
-	for idx, tables := range snap.Order {
-		for _, table := range tables {
-			found.Put(table.Table(), idx)
-			tableCount++
+	for _, tc := range tcs {
+		parent := ident.NewTable(schema, ident.New(tc.name))
+
+		expectedChildren := make([]ident.Table, len(tc.expectedChildren))
+		for idx, childRaw := range tc.expectedChildren {
+			expectedChildren[idx] = ident.NewTable(schema, ident.New(childRaw))
 		}
-	}
-	a.Equal(len(tcs), tableCount)
-	a.True(expected.Equal(found, cmap.Comparator[int]()))
 
-	// Ensure that we fail in a useful manner if there is a reference cycle.
+		foundChildren := refs.GetZero(parent)
+		a.Lenf(foundChildren, len(expectedChildren), "%s", parent)
+	}
+
+	// Ensure that the database query doesn't fail if there is a
+	// cyclical table dependency. Dealing with this condition is left to
+	// the caller.
 	switch pool.Product {
 	case types.ProductCockroachDB, types.ProductPostgreSQL:
 		_, err = pool.ExecContext(ctx, fmt.Sprintf(`
@@ -187,9 +196,8 @@ ALTER TABLE %[1]s.cycle_a ADD COLUMN ref int references %[1]s.cycle_b;
 	default:
 		r.FailNow("unsupported product")
 	}
-	err = fixture.Watcher.Refresh(ctx, pool)
-	a.ErrorContains(err, "cycle_a")
-	a.ErrorContains(err, "cycle_b")
+	_, err = getDependencyRefs(ctx, pool, schema)
+	r.NoError(err)
 }
 
 // TestNoDeferrableConstraints will act as a reminder if/when deferrable
@@ -221,50 +229,74 @@ func TestCrossSchemaTableReferencesPG(t *testing.T) {
 	a := assert.New(t)
 	r := require.New(t)
 
-	fixture, err := all.NewFixture(t)
+	fixture, err := base.NewFixture(t)
 	r.NoError(err)
 
 	ctx := fixture.Context
 	pool := fixture.TargetPool
 	db, _ := fixture.TargetSchema.Split()
+
+	// Primary must sort before secondary since we test stable output.
+	primary := fixture.TargetSchema.Schema()
+	var secondary ident.Schema
+
 	switch pool.Product {
 	case types.ProductPostgreSQL:
 		// In Postgres we can only create schemas in the current database
 		// As a workaroud, using information_schema.
-		stm := fmt.Sprintf(`
-		CREATE TABLE %[1]s.parent (pk int primary key);
-		CREATE TABLE %[2]s.child (pk int primary key, parent int references %[1]s.parent);
-		CREATE TABLE %[1]s.child (pk int primary key, parent int references %[2]s.child);
-		`, fixture.TargetSchema, "information_schema")
-		_, err = pool.ExecContext(ctx, stm)
+		secondary, err = ident.NewSchema(db, ident.New("information_schema"))
 		r.NoError(err)
-	case types.ProductCockroachDB:
 
-		other, err := ident.NewSchema(db, ident.New("other"))
+	case types.ProductCockroachDB:
+		secondary, err = ident.NewSchema(db, ident.New("other"))
 		r.NoError(err)
-		stm := fmt.Sprintf(`
-		CREATE SCHEMA %[2]s;
-		CREATE TABLE %[1]s.parent (pk int primary key);
-		CREATE TABLE %[2]s.child (pk int primary key, parent int references %[1]s.parent);
-		CREATE TABLE %[1]s.child (pk int primary key, parent int references %[2]s.child);
-		`, fixture.TargetSchema, other)
-		_, err = pool.ExecContext(ctx, stm)
+
+		_, err = pool.ExecContext(ctx, fmt.Sprintf(`CREATE SCHEMA %s`, secondary))
 		r.NoError(err)
+
 	default:
 		t.Skip("only for CRDB/Postgres")
 	}
-	r.NoError(fixture.Watcher.Refresh(ctx, pool))
-	snap := fixture.Watcher.Get()
-	for idx, tables := range snap.Order {
-		switch idx {
-		case 0:
-			r.Equal(1, len(tables))
-			a.True(ident.Equal(ident.New("parent"), tables[0].Table()))
-			a.True(ident.Equal(fixture.TargetSchema, tables[0].Schema()))
-		case 2:
-			r.Equal(1, len(tables))
-			a.True(ident.Equal(ident.New("child"), tables[0].Table()))
-			a.True(ident.Equal(fixture.TargetSchema, tables[0].Schema()))
+
+	// Construct the expected schema data.
+	parent := ident.NewTable(primary, ident.New("parent"))
+	childPrimary := ident.NewTable(primary, ident.New("child"))
+	childSecondary := ident.NewTable(secondary, ident.New("child"))
+
+	expectMap := &ident.TableMap[[]ident.Table]{}
+	tcs := []struct {
+		parent   ident.Table
+		children []ident.Table
+	}{
+		{parent, []ident.Table{childPrimary, childSecondary}},
+		{childPrimary, nil},
+		{childSecondary, nil},
+	}
+	for _, tc := range tcs {
+		expectMap.Put(tc.parent, tc.children)
+	}
+	expectSchema := &types.SchemaData{}
+	r.NoError(expectSchema.SetDependencies(expectMap))
+
+	// Create target tables.
+	q := fmt.Sprintf(`
+CREATE TABLE %[1]s.parent (pk int primary key);
+CREATE TABLE %[2]s.child (pk int primary key, parent int references %[1]s.parent);
+CREATE TABLE %[1]s.child (pk int primary key, parent int references %[2]s.child);
+`, primary, secondary)
+	_, err = pool.ExecContext(ctx, q)
+	r.NoError(err)
+
+	// Execute queries and validate computed schema data.
+	refs, err := getDependencyRefs(ctx, pool, primary)
+	r.NoError(err)
+
+	foundSchema := &types.SchemaData{}
+	r.NoError(foundSchema.SetDependencies(refs))
+	if a.Len(foundSchema.Entire.Order, len(expectSchema.Entire.Order)) {
+		for idx, table := range expectSchema.Entire.Order {
+			found := foundSchema.Entire.Order[idx]
+			a.True(ident.Equal(table, found))
 		}
 	}
 }

--- a/internal/target/schemawatch/watcher.go
+++ b/internal/target/schemawatch/watcher.go
@@ -127,38 +127,6 @@ func (w *watcher) Refresh(ctx context.Context, tx *types.TargetPool) error {
 	return nil
 }
 
-// Snapshot returns the known tables in the given user-defined schema.
-func (w *watcher) Snapshot(in ident.Schema) *types.SchemaData {
-	data := w.Get()
-
-	ret := &types.SchemaData{
-		Columns: &ident.TableMap[[]types.ColData]{},
-		Order:   make([][]ident.Table, 0, len(data.Order)),
-	}
-
-	_ = data.Columns.Range(func(table ident.Table, cols []types.ColData) error {
-		if in.Contains(table) {
-			// https://github.com/golang/go/wiki/SliceTricks#copy
-			out := make([]types.ColData, len(cols))
-			copy(out, cols)
-			ret.Columns.Put(table, out)
-		}
-		return nil
-	})
-	for _, tables := range data.Order {
-		filtered := make([]ident.Table, 0, len(tables))
-		for _, tbl := range tables {
-			if in.Contains(tbl) {
-				filtered = append(filtered, tbl)
-			}
-		}
-		if len(filtered) > 0 {
-			ret.Order = append(ret.Order, filtered)
-		}
-	}
-	return ret
-}
-
 // String is for debugging use only.
 func (w *watcher) String() string {
 	return fmt.Sprintf("Watcher(%s)", w.schema)
@@ -301,12 +269,19 @@ func (w *watcher) getTables(ctx context.Context, tx *types.TargetPool) (*types.S
 			}
 			ret.Columns.Put(tbl, cols)
 		}
+		if err != nil {
+			return err
+		}
 
 		// Empty if there were no tables.
-		if !sch.Empty() {
-			ret.Order, err = getDependencyOrder(ctx, tx, sch)
+		if sch.Empty() {
+			return nil
 		}
-		return err
+		order, err := getDependencyRefs(ctx, tx, sch)
+		if err != nil {
+			return err
+		}
+		return ret.SetDependencies(order)
 	})
 
 	return ret, err

--- a/internal/types/schema_data.go
+++ b/internal/types/schema_data.go
@@ -1,0 +1,268 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+
+	"github.com/cockroachdb/replicator/internal/util/ident"
+	"github.com/pkg/errors"
+)
+
+// ColData hold SQL column metadata.
+type ColData struct {
+	// A SQL expression to use with sparse payloads.
+	DefaultExpr string      `json:"defaultExpr,omitempty"`
+	Ignored     bool        `json:"ignored,omitempty"`
+	Name        ident.Ident `json:"name,omitempty"`
+	// A Parse function may be supplied to allow a datatype
+	// to be converted into a type more readily
+	// used by a target database driver.
+	Parse   func(any) (any, error) `json:"-"`
+	Primary bool                   `json:"primary,omitempty"` // PK column.
+	Type    string                 `json:"type,omitempty"`    // Data type of the column.
+}
+
+// Equal returns true if the two ColData are equivalent under
+// case-insensitivity.
+func (d ColData) Equal(o ColData) bool {
+	return d.DefaultExpr == o.DefaultExpr &&
+		d.Ignored == o.Ignored &&
+		ident.Equal(d.Name, o.Name) &&
+		// Parse is excluded, since functions are not comparable.
+		d.Primary == o.Primary &&
+		d.Type == o.Type
+}
+
+// SchemaComponent represents a strongly-connected component based
+// on foreign-key relationships.
+type SchemaComponent struct {
+	// Order is sorted such that parent tables will appear before child
+	// tables.
+	Order []ident.Table `json:"order"`
+
+	// ReverseOrder is sorted such that child tables will appear before
+	// parent tables.
+	ReverseOrder []ident.Table `json:"-"`
+}
+
+// sort the tables by level and then by name.
+func (c *SchemaComponent) sort(levels *ident.TableMap[int]) error {
+	slices.SortFunc(c.Order, func(a, b ident.Table) int {
+		if c := levels.GetZero(a) - levels.GetZero(b); c != 0 {
+			return c
+		}
+		return strings.Compare(a.Canonical().Raw(), b.Canonical().Raw())
+	})
+
+	c.ReverseOrder = slices.Clone(c.Order)
+	slices.Reverse(c.ReverseOrder)
+	return nil
+}
+
+// SchemaData holds SQL schema metadata.
+type SchemaData struct {
+	// Columns describes table columns. Primary keys will appear first
+	// in the slice, in table-column order. The remaining columns will
+	// be sorted by name.
+	Columns *ident.TableMap[[]ColData]
+
+	// Components describes strongly-connected component relationships
+	// of the tables in the schema. That is, each element represents a
+	// group of tables that have a FK relationship that must be handled
+	// in a transactionally-consistent fashion.
+	Components []*SchemaComponent
+
+	// Dependencies contains a mapping of parent tables to child tables.
+	Dependencies *ident.TableMap[[]ident.Table]
+
+	// Entire is a flattened view of all Components.
+	Entire *SchemaComponent
+
+	// TableComponents is an index into Components.
+	TableComponents *ident.TableMap[*SchemaComponent]
+}
+
+var (
+	_ json.Marshaler   = (*SchemaData)(nil)
+	_ json.Unmarshaler = (*SchemaData)(nil)
+)
+
+// schemaDataPayload is a flattened representation of [SchemaData].
+type schemaDataPayload struct {
+	Columns      *ident.TableMap[[]ColData]     `json:"columns"`
+	Dependencies *ident.TableMap[[]ident.Table] `json:"dependencies"`
+}
+
+// MarshalJSON implements [json.Marshaler].
+func (s *SchemaData) MarshalJSON() ([]byte, error) {
+	p := &schemaDataPayload{
+		Columns:      s.Columns,
+		Dependencies: s.Dependencies,
+	}
+
+	return json.Marshal(p)
+}
+
+// UnmarshalJSON implements [json.Unmarshaler]. This method will not
+// restore the [ColData.Parse] fields.
+func (s *SchemaData) UnmarshalJSON(data []byte) error {
+	p := &schemaDataPayload{}
+	if err := json.Unmarshal(data, p); err != nil {
+		return errors.WithStack(err)
+	}
+
+	s.Columns = p.Columns
+	return s.SetDependencies(p.Dependencies)
+}
+
+// SetDependencies initializes many of the SchemaData fields.
+func (s *SchemaData) SetDependencies(parentsToChildren *ident.TableMap[[]ident.Table]) error {
+	// We're going to copy the input data.
+	s.Dependencies = &ident.TableMap[[]ident.Table]{}
+
+	allTables := &ident.TableMap[struct{}]{}
+	isChild := &ident.TableMap[bool]{}
+	// Callback returns nil.
+	_ = parentsToChildren.Range(func(table ident.Table, children []ident.Table) error {
+		// Create a stable, shallow copy.
+		children = slices.Clone(children)
+		slices.SortFunc(children, func(a, b ident.Table) int { return ident.Compare(a, b) })
+		s.Dependencies.Put(table, children)
+
+		allTables.Put(table, struct{}{})
+		for _, child := range children {
+			allTables.Put(child, struct{}{})
+
+			// Don't treat self-referential tables as a child.
+			if !ident.Equal(table, child) {
+				isChild.Put(child, true)
+			}
+		}
+		return nil
+	})
+
+	// Recursively assign tables into groups and levels, starting with
+	// root tables.
+	assigned := &ident.TableMap[bool]{}
+	assignments := &ident.TableMap[*SchemaComponent]{}
+	levels := &ident.TableMap[int]{}
+	// Callback returns nil.
+	_ = parentsToChildren.Range(func(table ident.Table, _ []ident.Table) error {
+		if !isChild.GetZero(table) {
+			assign(table, table, parentsToChildren, assigned, assignments, levels, 0)
+		}
+		return nil
+	})
+
+	s.Components = make([]*SchemaComponent, 0, assignments.Len())
+	s.Entire = &SchemaComponent{}
+	s.TableComponents = &ident.TableMap[*SchemaComponent]{}
+
+	// Unpack the assigned groups, sorting the tables by dependency
+	// order.
+	if err := assignments.Range(func(_ ident.Table, comp *SchemaComponent) error {
+		s.Components = append(s.Components, comp)
+		s.Entire.Order = append(s.Entire.Order, comp.Order...)
+		for _, table := range comp.Order {
+			s.TableComponents.Put(table, comp)
+		}
+		return comp.sort(levels)
+	}); err != nil {
+		return err
+	}
+
+	// Ensure that all input tables have been assigned to a component.
+	// Tables involved in a reference cycle will
+	if s.TableComponents.Len() != allTables.Len() {
+		var sb strings.Builder
+		_ = allTables.Range(func(table ident.Table, _ struct{}) error {
+			if _, found := s.TableComponents.Get(table); !found {
+				if sb.Len() > 0 {
+					sb.WriteString(", ")
+				}
+				sb.WriteString(table.String())
+			}
+			return nil
+		})
+		return errors.Errorf("cycle detected in tables: %s", sb.String())
+	}
+	if err := s.Entire.sort(levels); err != nil {
+		return err
+	}
+
+	// Sort components by shortest-first and then by name of 0th element
+	// to ensure stable output. This works because we know that a table
+	// cannot be in two groups at once.
+	slices.SortFunc(s.Components, func(a, b *SchemaComponent) int {
+		if c := len(a.Order) - len(b.Order); c != 0 {
+			return c
+		}
+		return strings.Compare(
+			a.Order[0].Canonical().Raw(),
+			b.Order[0].Canonical().Raw())
+	})
+	return nil
+}
+
+// OriginalName returns the name of the table as it is defined in the
+// underlying database.
+func (s *SchemaData) OriginalName(tbl ident.Table) (ident.Table, bool) {
+	ret, _, ok := s.Columns.Match(tbl)
+	return ret, ok
+}
+
+// assign recursively aggregates the tables into groups reachable from
+// some particular root. It also tracks the maximum referential depth
+// for any given table. We don't need to worry about cyclical table
+// references, since a cyclic table wouldn't have been classified as a
+// root. This is, essentially, the second half of Kosaraju's algorithm
+// with traversal-depth. We already have a complete pre-order of the
+// root tables, so we can skip the visit phase.
+func assign(
+	table, root ident.Table,
+	parentsToChildren *ident.TableMap[[]ident.Table],
+	assigned *ident.TableMap[bool],
+	assignments *ident.TableMap[*SchemaComponent],
+	levels *ident.TableMap[int],
+	level int,
+) {
+
+	// We always want to increase a table's level.
+	levels.Put(table, max(level, levels.GetZero(table)))
+
+	// Process tables once.
+	if assigned.GetZero(table) {
+		return
+	}
+	assigned.Put(table, true)
+
+	// Add table to its component.
+	assignment, ok := assignments.Get(root)
+	if !ok {
+		assignment = &SchemaComponent{}
+		assignments.Put(root, assignment)
+	}
+	assignment.Order = append(assignment.Order, table)
+
+	// Recurse over child tables.
+	for _, child := range parentsToChildren.GetZero(table) {
+		assign(child, root, parentsToChildren, assigned, assignments, levels, level+1)
+	}
+}

--- a/internal/types/schema_data_test.go
+++ b/internal/types/schema_data_test.go
@@ -1,0 +1,230 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/cockroachdb/replicator/internal/util/ident"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetComponents(t *testing.T) {
+	r := require.New(t)
+
+	const bigGroupSize = 10
+	const numComps = 4
+	tcs := []struct {
+		name      string
+		order     int // Ensure stable, schema-wide ordering
+		groupSize int
+		parents   []string
+	}{
+		{
+			"parent",
+			1,
+			bigGroupSize,
+			nil,
+		},
+		{
+			"another_table",
+			0,
+			1,
+			nil,
+		},
+		{
+			"unreferenced",
+			2,
+			1,
+			nil,
+		},
+		{
+			"child",
+			3,
+			bigGroupSize,
+			[]string{"parent"},
+		},
+		{
+			"child_2",
+			4,
+			bigGroupSize,
+			[]string{"parent"},
+		},
+		{
+			"grandchild",
+			7,
+			bigGroupSize,
+			[]string{"child"},
+		},
+		{
+			"grandchild_2",
+			8,
+			bigGroupSize,
+			[]string{"child_2"},
+		},
+		{
+			"grandchild_multi",
+			9,
+			bigGroupSize,
+			[]string{"child", "child_2"},
+		},
+		{
+			"three",
+			10,
+			bigGroupSize,
+			[]string{"parent", "grandchild"},
+		},
+		{
+			"four",
+			11,
+			bigGroupSize,
+			[]string{"parent", "three"},
+		},
+		{
+			"five",
+			12,
+			bigGroupSize,
+			[]string{"parent", "four"},
+		},
+		{
+			"six",
+			13,
+			bigGroupSize,
+			[]string{"parent", "five"},
+		},
+		// Verify that a self-referential table returns reasonable values.
+		{
+			"self",
+			5,
+			2,
+			[]string{"self"},
+		},
+		{
+			"self_child",
+			6,
+			2,
+			[]string{"self"},
+		},
+	}
+
+	refs := &ident.TableMap[[]ident.Table]{}
+	schema := ident.MustSchema(ident.New("schema"))
+	tables := make([]ident.Table, len(tcs))
+
+	sd := &SchemaData{
+		Columns: &ident.TableMap[[]ColData]{},
+	}
+	for idx, tcs := range tcs {
+		table := ident.NewTable(schema, ident.New(tcs.name))
+		tables[idx] = table
+
+		// Add some fake column data to test serialization below.
+		sd.Columns.Put(table, []ColData{
+			{Name: ident.New("pk"), Primary: true, Type: "int"},
+			{Name: ident.New("val"), Type: "varchar"},
+		})
+
+		// Ensure stub entry for tables.
+		refs.Put(table, refs.GetZero(table))
+
+		for _, parentRaw := range tcs.parents {
+			parent := ident.NewTable(schema, ident.New(parentRaw))
+			refs.Put(parent, append(refs.GetZero(parent), table))
+		}
+	}
+
+	r.NoError(sd.SetDependencies(refs))
+
+	t.Run("setDependencies", func(t *testing.T) {
+		r := require.New(t)
+		r.Len(sd.Components, numComps)
+		r.Len(sd.Entire.Order, len(tcs))
+		r.Equal(len(tcs), sd.TableComponents.Len())
+
+		globalOrder := func(table ident.Table) int {
+			return slices.IndexFunc(sd.Entire.Order, func(elt ident.Table) bool {
+				return ident.Equal(elt, table)
+			})
+		}
+
+		for idx, tcs := range tcs {
+			table := tables[idx]
+			comp, ok := sd.TableComponents.Get(table)
+			r.Truef(ok, "%s", table)
+			r.NotNilf(comp, "%s", table)
+			r.Lenf(comp.Order, tcs.groupSize, "%s", table)
+
+			// Verify global ordering is correct.
+			r.Equalf(tcs.order, globalOrder(table), "%s", table)
+
+		}
+
+		for _, comp := range sd.Components {
+			// Verify order within the component aligns with global order.
+			r.True(slices.IsSortedFunc(comp.Order, func(a, b ident.Table) int {
+				aIdx := globalOrder(a)
+				bIdx := globalOrder(b)
+				return aIdx - bIdx
+			}))
+
+			r.Equal(len(comp.Order), len(comp.ReverseOrder))
+		}
+	})
+
+	// Since we have a fully-formed SchemaData, we'll also take this
+	// opportunity to test the serialization code. This gets more of a
+	// workout in the schemawatch package.
+	t.Run("test_serialization", func(t *testing.T) {
+		r := require.New(t)
+
+		data, err := sd.MarshalJSON()
+		r.NoError(err)
+		t.Log(string(data))
+
+		next := &SchemaData{}
+		r.NoError(next.UnmarshalJSON(data))
+
+		r.Equal(sd.Columns.Len(), next.Columns.Len())
+		_ = sd.Columns.Range(func(table ident.Table, cols []ColData) error {
+			found := next.Columns.GetZero(table)
+			r.Len(found, len(cols))
+			for i := range cols {
+				r.True(cols[i].Equal(found[i]))
+			}
+			return nil
+		})
+		r.Equal(sd.Dependencies.Len(), next.Dependencies.Len())
+		_ = sd.Dependencies.Range(func(table ident.Table, deps []ident.Table) error {
+			found := next.Dependencies.GetZero(table)
+			r.Len(found, len(deps))
+			for i := range deps {
+				r.True(ident.Equal(deps[i], found[i]))
+			}
+			return nil
+		})
+	})
+
+	t.Run("check_cycle", func(t *testing.T) {
+		r := require.New(t)
+		cycle1 := ident.NewTable(schema, ident.New("cycle1"))
+		cycle2 := ident.NewTable(schema, ident.New("cycle2"))
+		refs.Put(cycle1, []ident.Table{cycle2})
+		refs.Put(cycle2, []ident.Table{cycle1})
+		r.ErrorContains(sd.SetDependencies(refs), "cycle detected")
+	})
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -279,54 +279,6 @@ type Stagers interface {
 	Read(ctx *stopper.Context, q *StagingQuery) (<-chan *StagingCursor, error)
 }
 
-// ColData hold SQL column metadata.
-type ColData struct {
-	// A SQL expression to use with sparse payloads.
-	DefaultExpr string
-	Ignored     bool
-	Name        ident.Ident
-	// A Parse function may be supplied to allow a datatype
-	// to be converted into a type more readily
-	// used by a target database driver.
-	Parse   func(any) (any, error) `json:"-"`
-	Primary bool
-	// Type of the column.
-	Type string
-}
-
-// Equal returns true if the two ColData are equivalent under
-// case-insensitivity.
-func (d ColData) Equal(o ColData) bool {
-	return d.DefaultExpr == o.DefaultExpr &&
-		d.Ignored == o.Ignored &&
-		ident.Equal(d.Name, o.Name) &&
-		// Parse is excluded, since functions are not comparable.
-		d.Primary == o.Primary &&
-		d.Type == o.Type
-}
-
-// SchemaData holds SQL schema metadata.
-type SchemaData struct {
-	Columns *ident.TableMap[[]ColData]
-
-	// Order is a two-level slice that represents equivalency-groups
-	// with respect to table foreign-key ordering. That is, if all
-	// updates for tables in Order[N] are applied, then updates in
-	// Order[N+1] can then be applied.
-	//
-	// The need for this data can be revisited if CRDB adds support
-	// for deferrable foreign-key constraints:
-	// https://github.com/cockroachdb/cockroach/issues/31632
-	Order [][]ident.Table
-}
-
-// OriginalName returns the name of the table as it is defined in the
-// underlying database.
-func (s *SchemaData) OriginalName(tbl ident.Table) (ident.Table, bool) {
-	ret, _, ok := s.Columns.Match(tbl)
-	return ret, ok
-}
-
 // Product is an enum type to make it easy to switch on the underlying
 // database.
 type Product int


### PR DESCRIPTION
Previously, the table-dependency queries asked the target database to return the referential level of tables in the target schema. This change updates the queries to return parent-child tuples and computes the table-level within Replicator. Having the extra data within Replicator also allows us to compute the strongly-connected FK components within the target schema. This will enable an upcoming change to BestEffort mode to allow it to operate over groups of connected tables, rather than on a per-table basis.

Summary of changes:
- The SchemaData and ColData types are moved into a new file, schema_data_test.go.
- A SchemaData now expresses a variety of relationships between connected tables. This necessitates an update to how a SchemaData is serialized, and has a few knock-on effects in the schema backup code.
- An unreferenced method, watcher.Snapshot() is deleted.
- The queries in dependencies.go are updated to return tuples of parent-to-child relationships. These values are processed by a new SchemaData.SetDependencies() method that populates the component-related fields.
- The aggregation behavior in orderedAcceptor is updated to iterate over tables in reverse-dependency order when encountering deletions.
- The Oracle schema queries are run with the gather_plan_statistics hint, which seems to allow the optimizer to significantly improve the speeds of these queries.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/991)
<!-- Reviewable:end -->
