### PR TITLE
oracle: Reconnect as a new role for each fixture

### DIFF
--- a/internal/sinktest/base/provider.go
+++ b/internal/sinktest/base/provider.go
@@ -23,7 +23,9 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net/url"
 	"os"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -43,6 +45,9 @@ import (
 
 const (
 	defaultConnString = "postgresql://root@localhost:26257/defaultdb?sslmode=disable"
+
+	// DummyPassword is baked into the docker-compose configuration.
+	DummyPassword = "SoupOrSecret"
 
 	envSourceString  = "TEST_SOURCE_CONNECT"
 	envStagingString = "TEST_STAGING_CONNECT"
@@ -304,11 +309,31 @@ func ProvideTargetSchema(
 	if pool.Info().Product == types.ProductPostgreSQL {
 		db, _ := sch.Split()
 		conn := fmt.Sprintf("%s/%s", pool.ConnectionString, db.Raw())
-		next, err := stdpool.OpenPgxAsTarget(ctx, conn, stdpool.WithDiagnostics(diags, "target_reopened"))
+		next, err := stdpool.OpenPgxAsTarget(ctx, conn,
+			stdpool.WithDiagnostics(diags, "target_reopened"))
 		if err != nil {
 			return sinktest.TargetSchema{}, err
 		}
 
+		nextCache := ProvideTargetStatements(ctx, next)
+		pool.ConnectionString = conn
+		pool.DB = next.DB
+		stmts.Cache = nextCache.Cache
+	} else if pool.Info().Product == types.ProductOracle {
+		// Similar to the above, we want to reconnect as something other
+		// than the system user the test stack is initialized with.
+		u, err := url.Parse(pool.ConnectionString)
+		if err != nil {
+			return sinktest.TargetSchema{}, errors.Wrap(err, pool.ConnectionString)
+		}
+		u.User = url.UserPassword(sch.Raw(), DummyPassword)
+		conn := u.String()
+
+		next, err := stdpool.OpenOracleAsTarget(ctx, conn,
+			stdpool.WithDiagnostics(diags, "target_reopened"))
+		if err != nil {
+			return sinktest.TargetSchema{}, err
+		}
 		nextCache := ProvideTargetStatements(ctx, next)
 		pool.ConnectionString = conn
 		pool.DB = next.DB
@@ -337,9 +362,12 @@ func provideSchema[P types.AnyPool](
 		// "globally" unique ID.  While PIDs do recycle, they're highly
 		// unlikely to do so during a single run of the test suite.
 		name := ident.New(fmt.Sprintf(
-			"%s_%d_%d", prefix, os.Getpid(), dbIdentCounter.Add(1)))
+			"%s_%d_%d", strings.ToUpper(prefix), os.Getpid(), dbIdentCounter.Add(1)))
 
-		err := retry.Execute(ctx, pool, fmt.Sprintf("CREATE USER %s", name))
+		// This syntax doesn't use a string literal, but an identifier
+		// for the password.
+		err := retry.Execute(ctx, pool, fmt.Sprintf(
+			"CREATE USER %s IDENTIFIED BY %s", name, DummyPassword))
 		if err != nil {
 			return ident.Schema{}, errors.Wrapf(err, "could not create user %s", name)
 		}
@@ -347,6 +375,12 @@ func provideSchema[P types.AnyPool](
 		err = retry.Execute(ctx, pool, fmt.Sprintf("ALTER USER %s QUOTA UNLIMITED ON USERS", name))
 		if err != nil {
 			return ident.Schema{}, errors.Wrapf(err, "could not grant quota to %s", name)
+		}
+
+		err = retry.Execute(ctx, pool, fmt.Sprintf(
+			"GRANT CREATE SESSION, CREATE SEQUENCE, CREATE TABLE, CREATE TYPE, CREATE VIEW TO %s", name))
+		if err != nil {
+			return ident.Schema{}, errors.Wrapf(err, "could not grant permissions to %s", name)
 		}
 
 		ctx.Defer(func() {

--- a/internal/util/stdpool/ora.go
+++ b/internal/util/stdpool/ora.go
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build cgo && linux && (target_oracle || target_all)
+//go:build cgo && (target_oracle || target_all)
 
 package stdpool
 

--- a/internal/util/stdpool/ora_unsupported.go
+++ b/internal/util/stdpool/ora_unsupported.go
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build !(cgo && linux && (target_oracle || target_all))
+//go:build !(cgo && (target_oracle || target_all))
 
 package stdpool
 


### PR DESCRIPTION
This change updates how the Oracle Database connection pool is set up. Rather than running tests while connected as the SYSTEM user, we'll reconnect as the role we've already created for the fixture's tables. This will help identify explicit grants that a Replicator role may require in the future.

This change also removes the linux build tag from ora.go. Oracle Instant Client libraries are now available for ARM-based Macs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/994)
<!-- Reviewable:end -->
