### PR TITLE
apply: Fold sparse mutations

### DIFF
--- a/internal/sequencer/besteffort/direct.go
+++ b/internal/sequencer/besteffort/direct.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/replicator/internal/util/ident"
 	"github.com/cockroachdb/replicator/internal/util/lockset"
 	"github.com/cockroachdb/replicator/internal/util/metrics"
-	"github.com/cockroachdb/replicator/internal/util/msort"
 	"github.com/jackc/pgx/v5"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -108,10 +107,9 @@ func (a *directAcceptor) AcceptTableBatch(
 
 		// Apply the remaining mutations. This call disregards the
 		// original options, since we wouldn't want to use any
-		// pre-existing transaction. We'll also apply a last-one-wins
-		// approach to further reduce the number of applied mutations.
+		// pre-existing transaction.
 		attemptBatch := batch.Empty()
-		attemptBatch.Data = msort.UniqueByKey(attempt)
+		attemptBatch.Data = attempt
 		if err = a.apply.AcceptTableBatch(ctx, attemptBatch, &types.AcceptOptions{}); err != nil {
 			return err
 		}

--- a/internal/util/msort/msort.go
+++ b/internal/util/msort/msort.go
@@ -19,41 +19,122 @@
 package msort
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"slices"
 
 	"github.com/cockroachdb/replicator/internal/types"
 	"github.com/cockroachdb/replicator/internal/util/hlc"
+	"github.com/pkg/errors"
 )
 
-// UniqueByKey implements a "last one wins" approach to removing
-// mutations with duplicate keys from the input slice. If two mutations
-// share the same Key, then the one with the later Time is returned. If
-// there are mutations with identical Keys and Times, exactly one of the
-// values will be chosen arbitrarily.
+// FoldByKey implements a folding approach to removing mutations with
+// duplicate keys from the input slice. If two mutations share the same
+// Key, their data blocks will be merged on a key-by-key basis.
+// Mutations will be processed in time order.
 //
-// A new slice is returned.
-//
-// This function will panic if any of the mutation Key fields are
-// entirely empty. An empty json array (i.e. `[]`) is acceptable.
-func UniqueByKey(x []types.Mutation) []types.Mutation {
-	return uniqueBy(x,
-		func(e types.Mutation) string {
-			key := string(e.Key)
-			// This is a sanity-check to ensure that we don't silently
-			// discard mutations due to some upstream coding error where a
-			// mutation does not have its Key field set.
-			if len(key) == 0 {
-				panic("empty key")
+// This function will not modify the input slice, but may return it if
+// all mutations were applied to unique keys.
+func FoldByKey(x []types.Mutation) ([]types.Mutation, error) {
+	// Handle trivial cases.
+	if len(x) <= 1 {
+		return x, nil
+	}
+	// Ensure that values in the slice are well-ordered. This should be
+	// the general case.
+	sorted := slices.IsSortedFunc(x, func(a, b types.Mutation) int {
+		return hlc.Compare(a.Time, b.Time)
+	})
+	if !sorted {
+		x = slices.Clone(x)
+		slices.SortStableFunc(x, func(a, b types.Mutation) int {
+			return hlc.Compare(a.Time, b.Time)
+		})
+	}
+	exemplars := make(map[string]*types.Mutation, len(x))
+	keyData := make(map[string]map[string]json.RawMessage, len(x))
+
+	for idx, mut := range x {
+		if len(mut.Key) == 0 {
+			return nil, errors.New("mutation key must not be empty")
+		}
+		key := string(mut.Key)
+		exemplar, collision := exemplars[key]
+
+		// Last-one-wins for any other metadata (i.e. deletions).
+		exemplars[key] = &x[idx]
+
+		// Do nothing until we see a collision on the key. This should
+		// be the general case.
+		if !collision {
+			continue
+		}
+
+		// The previous mutation for this key was a deletion, we can
+		// just keep the current mutation.
+		if exemplar.IsDelete() {
+			continue
+		}
+
+		// Drop previous merges if the new key is a deletion.
+		if mut.IsDelete() {
+			delete(keyData, key)
+			continue
+		}
+
+		// We're in a condition that requires folding.
+		acc, exemplarUnpacked := keyData[key]
+
+		// If this is first time we encounter a collision, unpack the
+		// exemplar into the map. If the previous value was a deletion,
+		// we don't need to do anything further.
+		if !exemplarUnpacked {
+			acc = make(map[string]json.RawMessage)
+			keyData[key] = acc
+
+			dec := json.NewDecoder(bytes.NewReader(exemplar.Data))
+			dec.UseNumber()
+			if err := dec.Decode(&acc); err != nil {
+				return nil, errors.WithStack(err)
 			}
-			return key
-		},
-		func(existing, matching types.Mutation) types.Mutation {
-			if hlc.Compare(existing.Time, matching.Time) >= 0 {
-				return existing
-			}
-			return matching
-		},
-	)
+		}
+
+		// Patch the map with the next mutation.
+		dec := json.NewDecoder(bytes.NewReader(mut.Data))
+		dec.UseNumber()
+		if err := dec.Decode(&acc); err != nil {
+			return nil, errors.WithStack(err)
+		}
+	}
+
+	// If there were no collisions and no deletions, return the original
+	// slice. This should be the general case.
+	if len(keyData) == 0 && len(exemplars) == len(x) {
+		return x, nil
+	}
+
+	// Reencode the folded mutations.
+	ret := make([]types.Mutation, 0, len(exemplars))
+	for key, exemplar := range exemplars {
+		merged, collision := keyData[key]
+		if !collision {
+			ret = append(ret, *exemplar)
+			continue
+		}
+		var err error
+		mut := *exemplar // Don't modify elements in original slice.
+		mut.Data, err = json.Marshal(merged)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		ret = append(ret, mut)
+	}
+	// Sort the output by key.
+	slices.SortFunc(ret, func(a, b types.Mutation) int {
+		return bytes.Compare(a.Key, b.Key)
+	})
+	return ret, nil
 }
 
 // UniqueByTimeKey implements a "last one wins" approach to removing

--- a/internal/util/msort/msort_test.go
+++ b/internal/util/msort/msort_test.go
@@ -17,7 +17,9 @@
 package msort
 
 import (
+	"encoding/json"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/cockroachdb/replicator/internal/types"
@@ -27,9 +29,13 @@ import (
 
 func mut(k int, v string, t ...hlc.Time) types.Mutation {
 	ret := types.Mutation{
-		Data: []byte(fmt.Sprintf(`{"key":%d, "value":%s}`, k, v)),
 		Key:  []byte(fmt.Sprintf(`[%d]`, k)),
 		Time: hlc.New(int64(k), k),
+	}
+	if v == "deleted" {
+		ret.Deletion = true
+	} else {
+		ret.Data = []byte(fmt.Sprintf(`{"key":%d,"value":%q}`, k, v))
 	}
 	if len(t) >= 1 {
 		ret.Time = t[0]
@@ -37,7 +43,7 @@ func mut(k int, v string, t ...hlc.Time) types.Mutation {
 	return ret
 }
 
-func TestUniqueByKey(t *testing.T) {
+func TestFoldByKey(t *testing.T) {
 	tcs := []struct {
 		data, expected []types.Mutation
 	}{
@@ -66,10 +72,10 @@ func TestUniqueByKey(t *testing.T) {
 				mut(3, "expected"),
 			},
 			expected: []types.Mutation{
-				mut(2, "expected"),
-				mut(4, "expected"),
 				mut(1, "expected"),
+				mut(2, "expected"),
 				mut(3, "expected"),
+				mut(4, "expected"),
 			},
 		},
 		{
@@ -79,20 +85,57 @@ func TestUniqueByKey(t *testing.T) {
 				mut(1, "expected"),
 			},
 			expected: []types.Mutation{
+				mut(1, "expected"),
+				mut(2, "expected"),
+			},
+		},
+		{
+			data: []types.Mutation{
+				mut(1, "deleted"),
 				mut(2, "expected"),
 				mut(1, "expected"),
+				mut(1, "deleted"),
+			},
+			expected: []types.Mutation{
+				mut(1, "deleted"),
+				mut(2, "expected"),
 			},
 		},
 		// Test the case where timestamps are out of order for a key.
 		{
 			data: []types.Mutation{
-				mut(1, "expected", hlc.New(100, 100)),
+				mut(1, "expected100", hlc.New(100, 100)),
 				mut(2, "expected"),
-				mut(1, "expected"),
+				mut(1, "expected1"),
 			},
 			expected: []types.Mutation{
+				mut(1, "expected100", hlc.New(100, 100)),
 				mut(2, "expected"),
-				mut(1, "expected", hlc.New(100, 100)),
+			},
+		},
+		// Verify property aggregation and sort stability.
+		{
+			data: []types.Mutation{
+				{
+					Key:  json.RawMessage(`[1]`),
+					Data: json.RawMessage(`{"k":1,"a":-999}`),
+				},
+				{
+					Key:  json.RawMessage(`[1]`),
+					Data: json.RawMessage(`{"k":1,"b":2}`),
+					Time: hlc.New(100, 100),
+				},
+				{
+					Key:  json.RawMessage(`[1]`),
+					Data: json.RawMessage(`{"k":1,"a":1,"c":3}`),
+				},
+			},
+			expected: []types.Mutation{
+				{
+					Key:  json.RawMessage(`[1]`),
+					Data: json.RawMessage(`{"a":1,"b":2,"c":3,"k":1}`),
+					Time: hlc.New(100, 100),
+				},
 			},
 		},
 	}
@@ -100,11 +143,25 @@ func TestUniqueByKey(t *testing.T) {
 	for idx, tc := range tcs {
 		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
 			a := assert.New(t)
-
-			data := UniqueByKey(tc.data)
+			originalData := slices.Clone(tc.data)
+			data, err := FoldByKey(tc.data)
+			a.NoError(err)
 			a.Equal(tc.expected, data)
+			// Verify function doesn't damage the input slice.
+			a.Equal(originalData, tc.data)
 		})
 	}
+}
+
+// Ensure error case if a mutation has no key.
+func TestFoldNoKey(t *testing.T) {
+	a := assert.New(t)
+	_, err := FoldByKey([]types.Mutation{
+		mut(1, "ok"),
+		{Key: nil},
+		mut(2, "ok"),
+	})
+	a.ErrorContains(err, "mutation key must not be empty")
 }
 
 func TestUniqueByTimeKey(t *testing.T) {
@@ -176,14 +233,4 @@ func TestUniqueByTimeKey(t *testing.T) {
 			a.Equal(tc.expected, data)
 		})
 	}
-}
-
-// Document the panic behavior.
-func TestUniqueByKeyPanic(t *testing.T) {
-	a := assert.New(t)
-	a.Panics(func() {
-		UniqueByKey([]types.Mutation{
-			{Key: nil},
-		})
-	})
 }


### PR DESCRIPTION
Some logical frontends may only be able to provide sparse row data and may also provide multiple updates to the same key within a single target transaction. This change adds a per-key folding behavior to coalesce multiple sparse mutations, rather than pushing the complexity to the frontend.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/1007)
<!-- Reviewable:end -->
