### PR TITLE
hlc: Introduce a monotonic Clock type

### DIFF
--- a/internal/sequencer/sequencer.go
+++ b/internal/sequencer/sequencer.go
@@ -87,9 +87,10 @@ func NewStat(group *types.TableGroup, progress *ident.TableMap[hlc.Range]) Stat 
 
 // CommonProgress returns the minimum progress across all tables within
 // the [Stat.Group]. If no progress has been made for one or more tables
-// in the group, [hlc.RangeEmpty] will be returned.
+// in the group, or if the group is empty, [hlc.RangeEmpty] will be
+// returned.
 func CommonProgress(s Stat) hlc.Range {
-	if s == nil {
+	if s == nil || len(s.Group().Tables) == 0 {
 		return hlc.RangeEmpty()
 	}
 	group := s.Group()

--- a/internal/sequencer/sequencer_test.go
+++ b/internal/sequencer/sequencer_test.go
@@ -52,4 +52,8 @@ func TestCommonProgress(t *testing.T) {
 	// All tables have progress.
 	progress.Put(group.Tables[1], hlc.RangeIncluding(hlc.Zero(), hlc.New(2, 1)))
 	r.Equal(hlc.RangeIncluding(hlc.Zero(), hlc.New(1, 1)), CommonProgress(stat))
+
+	// Empty group with no tables.
+	r.Equal(hlc.RangeEmpty(),
+		CommonProgress(NewStat(&types.TableGroup{}, &ident.TableMap[hlc.Range]{})))
 }

--- a/internal/source/mylogical/provider.go
+++ b/internal/source/mylogical/provider.go
@@ -80,7 +80,7 @@ func ProvideConn(
 	if err != nil {
 		return nil, err
 	}
-	connAcceptor, _, err := seq.Start(ctx, &sequencer.StartOptions{
+	connAcceptor, stat, err := seq.Start(ctx, &sequencer.StartOptions{
 		Delegate: types.OrderedAcceptorFrom(acc, watchers),
 		Bounds:   &notify.Var[hlc.Range]{}, // Not currently used.
 		Group: &types.TableGroup{
@@ -101,6 +101,7 @@ func ProvideConn(
 		relations:    make(map[uint64]ident.Table),
 		sourceConfig: cfg,
 		stagingDB:    stagingPool,
+		stat:         stat,
 		target:       config.TargetSchema,
 		targetDB:     targetPool,
 		walOffset:    notify.Var[*consistentPoint]{},

--- a/internal/source/pglogical/provider.go
+++ b/internal/source/pglogical/provider.go
@@ -111,7 +111,7 @@ func ProvideConn(
 	if err != nil {
 		return nil, err
 	}
-	connAcceptor, _, err := seq.Start(ctx, &sequencer.StartOptions{
+	connAcceptor, statVar, err := seq.Start(ctx, &sequencer.StartOptions{
 		Delegate: types.OrderedAcceptorFrom(acc, watchers),
 		Bounds:   &notify.Var[hlc.Range]{}, // Not currently used.
 		Group: &types.TableGroup{
@@ -133,6 +133,7 @@ func ProvideConn(
 		sourceConfig:    sourceConfig,
 		standbyTimeout:  config.StandbyTimeout,
 		stagingDB:       stagingPool,
+		stat:            statVar,
 		target:          config.TargetSchema,
 		targetDB:        targetPool,
 	}

--- a/internal/util/hlc/clock.go
+++ b/internal/util/hlc/clock.go
@@ -1,0 +1,115 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package hlc
+
+import (
+	"sync"
+	"time"
+)
+
+// A Clock generates a monotonic sequence of [Time] values, based on
+// some external logical clock and an approximate local wall time.
+//
+// The zero value is ready for use. A Clock is internally synchronized
+// and is safe for use by multiple goroutines.
+type Clock struct {
+	Wall func() int64 // Override wall source for testing.
+
+	mu struct {
+		sync.Mutex
+		last Time
+	}
+}
+
+// Advance returns a monotonic [Time] value that is equal to or greater
+// than the supplied timestamp.
+func (c *Clock) Advance(ts Time) Time {
+	return c.tick(ts.Nanos(), ts.Logical(), ts.External())
+}
+
+// External returns a monotonic [Time] value that will return the
+// argument via [Time.External]. Note that the external data is not
+// serialized by the Time type, nor does it affect comparisons between
+// Time values.
+//
+// This method is useful for logical frontends whose progress is
+// expressed via non-trivial datastructures (e.g. GTIDSet).
+func (c *Clock) External(data any) Time {
+	var proposedNanos int64
+	if c.Wall != nil {
+		proposedNanos = c.Wall()
+	} else {
+		proposedNanos = time.Now().UnixNano()
+	}
+	return c.tick(proposedNanos, 0, data)
+}
+
+// Last returns the most recently emitted Time.
+func (c *Clock) Last() Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.mu.last
+}
+
+// Logical returns a monotonic [Time] value based on an approximate wall
+// time and a supplied logical offset.
+func (c *Clock) Logical(logical int) Time {
+	var proposedNanos int64
+	if c.Wall != nil {
+		proposedNanos = c.Wall()
+	} else {
+		proposedNanos = time.Now().UnixNano()
+	}
+	return c.tick(proposedNanos, logical, nil)
+}
+
+// Now returns a monotonic [Time] value based on approximate wall time.
+func (c *Clock) Now() Time {
+	return c.Logical(0)
+}
+
+// Reset the clock to a specific time. This method does not preserve
+// monotonicity and should only be used to initialize a Clock.
+func (c *Clock) Reset(ts Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.mu.last = ts
+}
+
+func (c *Clock) tick(proposedNanos int64, logical int, ext any) Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	last := c.mu.last
+	var nextNanos int64
+	var nextLogical int
+	if (proposedNanos > last.Nanos()) ||
+		(proposedNanos == last.Nanos() && logical > last.Logical()) {
+		// The general case is that the wall time should advance or that
+		// we're within the wall time's resolution and the logical
+		// component has advanced.
+		nextNanos = proposedNanos
+		nextLogical = logical
+	} else {
+		// The clock and/or logical values have gone backwards.
+		nextNanos = last.Nanos() + 1
+		nextLogical = logical
+	}
+	ret := Time{nextNanos, nextLogical, ext}
+	c.mu.last = ret
+	return ret
+}

--- a/internal/util/hlc/clock_test.go
+++ b/internal/util/hlc/clock_test.go
@@ -1,0 +1,113 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package hlc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClock(t *testing.T) {
+	r := require.New(t)
+
+	wall := int64(100)
+	c := &Clock{
+		Wall: func() int64 { return wall },
+	}
+
+	last := c.Logical(0)
+	r.Equal(wall, last.Nanos())
+	r.Equal(0, last.Logical())
+
+	advanced := c.Advance(last)
+	r.True(Compare(advanced, last) > 0)
+
+	now := c.Now()
+	r.True(Compare(now, advanced) > 0)
+
+	logical := 2000
+	for i := range 100 {
+		next := c.Logical(logical)
+
+		// Time must always be monotonic.
+		r.True(Compare(next, last) > 0)
+
+		// Logical value must always match.
+		r.Equal(logical, next.Logical())
+
+		// Nanos must be non-zero and may run ahead of our wall time.
+		r.GreaterOrEqual(next.Nanos(), int64(0))
+		r.GreaterOrEqual(next.Nanos(), wall)
+
+		last = next
+
+		// Time passes...
+		switch i % 8 {
+		case 0:
+			// Logical ticks.
+			logical++
+
+		case 1:
+			// Wall time ticks.
+			wall++
+
+		case 2:
+			// Wall and logical tick.
+			logical++
+			wall++
+
+		case 3:
+			// Logical wraps.
+			logical -= 2
+
+		case 4:
+			// Wall goes backwards.
+			wall -= 2
+
+		case 5:
+			// Wall and logical both go backwards.
+			wall -= 2
+			logical -= 2
+
+		case 6:
+			// Nothing changes.
+			wall = last.Nanos()
+			logical = last.Logical()
+
+		case 7:
+			// Within timer resolution.
+			wall = last.Nanos()
+			logical = last.Logical() + 1
+		}
+	}
+	r.Equal(New(178, 1990), last)
+	r.Equal(last, c.Last())
+
+	// Force the clock to a specific value.
+	c.Reset(New(100, 100))
+	r.Equal(New(100, 100), c.Last())
+
+	// Check External function.
+	one := 1
+	ext := c.External(&one)
+	r.Same(&one, ext.External())
+
+	// Ensure relative times retain ext reference.
+	r.Same(&one, ext.Before().External())
+	r.Same(&one, ext.Next().External())
+}

--- a/internal/util/hlc/hlc_test.go
+++ b/internal/util/hlc/hlc_test.go
@@ -29,20 +29,20 @@ import (
 func TestBefore(t *testing.T) {
 	a := assert.New(t)
 
-	a.Equal(Time{1, 0}, Time{1, 1}.Before())
-	a.Equal(Time{1, math.MaxInt32}, Time{2, 0}.Before())
+	a.Equal(New(1, 0), New(1, 1).Before())
+	a.Equal(New(1, math.MaxInt32), New(2, 0).Before())
 }
 
 func TestCompare(t *testing.T) {
 	a := assert.New(t)
 
-	a.True(Compare(Time{1, 1}, Time{1, 1}) == 0)
+	a.True(Compare(New(1, 1), New(1, 1)) == 0)
 
-	a.True(Compare(Time{2, 1}, Time{1, 1}) > 0)
-	a.True(Compare(Time{1, 1}, Time{2, 1}) < 0)
+	a.True(Compare(New(2, 1), New(1, 1)) > 0)
+	a.True(Compare(New(1, 1), New(2, 1)) < 0)
 
-	a.True(Compare(Time{1, 2}, Time{1, 1}) > 0)
-	a.True(Compare(Time{1, 1}, Time{1, 2}) < 0)
+	a.True(Compare(New(1, 2), New(1, 1)) > 0)
+	a.True(Compare(New(1, 1), New(1, 2)) < 0)
 }
 
 func TestExtend(t *testing.T) {
@@ -115,10 +115,10 @@ func TestEmpty(t *testing.T) {
 	a := assert.New(t)
 
 	a.True(RangeEmpty().Empty())
-	a.True(RangeEmptyAt(Time{1, 0}).Empty())
+	a.True(RangeEmptyAt(New(1, 0)).Empty())
 
-	a.False(RangeIncluding(Time{1, 0}, Time{1, 0}).Empty())
-	a.False(RangeIncluding(Time{1, 0}, Time{1, 1}).Empty())
+	a.False(RangeIncluding(New(1, 0), New(1, 0)).Empty())
+	a.False(RangeIncluding(New(1, 0), New(1, 1)).Empty())
 }
 
 func TestWithMin(t *testing.T) {


### PR DESCRIPTION
As the number of logical frontends increases, the variety of external clock representations will continue to grow. This change introduces a monotonic Clock type and a way to associate an arbitrary external value with a Time.

Several frontends are updated to use a Clock instead of trying to adapt their upstream progress data into the Time type. The pglogical and mylogical frontends are prepared for an upcoming change to make them use an in-memory buffer around the core sequencer. Rather than generating MultiBatches, it is expected that frontends need only to assemble whole transactions in a TemporalBatch before handing the transaction off for processing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/1008)
<!-- Reviewable:end -->
