### PR TITLE
sequencer/script: Make sourceAcceptor implement MultiAcceptor

### DIFF
--- a/internal/sequencer/script/script.go
+++ b/internal/sequencer/script/script.go
@@ -127,12 +127,12 @@ func (w *wrapper) Start(
 	// Install the source-phase acceptor. This provides the user with
 	// the opportunity to rewrite mutations before they are presented to
 	// the upstream sequencer.
-	acc = types.UnorderedAcceptorFrom(&sourceAcceptor{
+	acc = &sourceAcceptor{
 		delegate:       acc,
 		group:          opts.Group,
 		sourceBindings: sourceBindings,
 		watcher:        watcher,
-	})
+	}
 	return acc, stat, nil
 }
 

--- a/internal/sequencer/script/source_acceptor.go
+++ b/internal/sequencer/script/source_acceptor.go
@@ -36,55 +36,38 @@ type sourceAcceptor struct {
 	watcher        types.Watcher
 }
 
-var _ types.TableAcceptor = (*sourceAcceptor)(nil)
+var _ types.MultiAcceptor = (*sourceAcceptor)(nil)
+
+func (a *sourceAcceptor) AcceptMultiBatch(
+	ctx context.Context, batch *types.MultiBatch, opts *types.AcceptOptions,
+) error {
+	return acceptBatch(ctx, a, batch, opts)
+}
 
 func (a *sourceAcceptor) AcceptTableBatch(
 	ctx context.Context, batch *types.TableBatch, opts *types.AcceptOptions,
 ) error {
-	// We're going to construct a new batch from the dispatched mutations.
+	return acceptBatch(ctx, a, batch, opts)
+}
+
+func (a *sourceAcceptor) AcceptTemporalBatch(
+	ctx context.Context, batch *types.TemporalBatch, opts *types.AcceptOptions,
+) error {
+	return acceptBatch(ctx, a, batch, opts)
+}
+
+// acceptBatch wants to be a generic method.
+func acceptBatch[B types.Batch[B]](
+	ctx context.Context, a *sourceAcceptor, batch B, opts *types.AcceptOptions,
+) error {
 	nextBatch := &types.MultiBatch{}
 
-	for _, mutToDispatch := range batch.Data {
-		script.AddMeta(a.group.Name.Raw(), batch.Table, &mutToDispatch)
-
-		isDelete := mutToDispatch.IsDelete()
-
-		dispatch := a.sourceBindings.Dispatch
-		fnName := "dispatch"
-		if isDelete {
-			// Same underlying func signature.
-			dispatch = script.Dispatch(a.sourceBindings.DeletesTo)
-			fnName = "deletesTo"
-		}
-
-		// Call the user function to see what mutations(s) go into which table(s).
-		dispatched, err := dispatch(ctx, batch.Table, mutToDispatch)
-		if err != nil {
-			return err
-		}
-		// Push the mutations into the replacement batch.
-		if err := dispatched.Range(func(table ident.Table, muts []types.Mutation) error {
-			if table.Empty() {
-				return errors.Errorf("%s returned an empty table name", fnName)
-			}
-			if _, found := a.watcher.Get().Columns.Get(table); !found {
-				return errors.Errorf(
-					"%s returned a table (%s) which does not exist in the target schema",
-					fnName, table)
-			}
-			for _, dispatchedMut := range muts {
-				dispatchedMut.Deletion = isDelete
-				// If the time were unset, it would trigger an error.
-				dispatchedMut.Time = mutToDispatch.Time
-				if err := nextBatch.Accumulate(table, dispatchedMut); err != nil {
-					return err
-				}
-			}
-			return err
-		}); err != nil {
-			return errors.Wrap(err, a.group.Name.Raw())
-		}
+	if err := batch.CopyInto(types.AccumulatorFunc(func(table ident.Table, mut types.Mutation) error {
+		return a.acceptOne(ctx, nextBatch, table, mut)
+	})); err != nil {
+		return err
 	}
+
 	// Calls to source.Dispatch may remove mutations.
 	// If the replacement batch is empty, we are done.
 	if nextBatch.Count() == 0 {
@@ -92,4 +75,49 @@ func (a *sourceAcceptor) AcceptTableBatch(
 	}
 
 	return a.delegate.AcceptMultiBatch(ctx, nextBatch, opts)
+}
+
+func (a *sourceAcceptor) acceptOne(
+	ctx context.Context, acc *types.MultiBatch, table ident.Table, mutToDispatch types.Mutation,
+) error {
+	script.AddMeta(a.group.Name.Raw(), table, &mutToDispatch)
+
+	isDelete := mutToDispatch.IsDelete()
+
+	dispatch := a.sourceBindings.Dispatch
+	fnName := "dispatch"
+	if isDelete {
+		// Same underlying func signature.
+		dispatch = script.Dispatch(a.sourceBindings.DeletesTo)
+		fnName = "deletesTo"
+	}
+
+	// Call the user function to see what mutations(s) go into which table(s).
+	dispatched, err := dispatch(ctx, table, mutToDispatch)
+	if err != nil {
+		return err
+	}
+	// Push the mutations into the replacement batch.
+	if err := dispatched.Range(func(table ident.Table, muts []types.Mutation) error {
+		if table.Empty() {
+			return errors.Errorf("%s returned an empty table name", fnName)
+		}
+		if _, found := a.watcher.Get().Columns.Get(table); !found {
+			return errors.Errorf(
+				"%s returned a table (%s) which does not exist in the target schema",
+				fnName, table)
+		}
+		for _, dispatchedMut := range muts {
+			dispatchedMut.Deletion = isDelete
+			// Preserve incoming timestamp.
+			dispatchedMut.Time = mutToDispatch.Time
+			if err := acc.Accumulate(table, dispatchedMut); err != nil {
+				return err
+			}
+		}
+		return err
+	}); err != nil {
+		return errors.Wrap(err, a.group.Name.Raw())
+	}
+	return nil
 }


### PR DESCRIPTION
This change makes sourceAcceptor implement the MultiAcceptor interface directly. This will send fewer, larger batches downstream.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/1013)
<!-- Reviewable:end -->
