### PR TITLE
sequencer: Extract staging behavior from core

### DIFF
--- a/internal/sequencer/besteffort/besteffort_test.go
+++ b/internal/sequencer/besteffort/besteffort_test.go
@@ -47,7 +47,9 @@ func TestBestEffort(t *testing.T) {
 					// We only want BestEffort to do work when told; the test
 					// rig uses a counter to generate timestamps.
 					seqFixture.BestEffort.SetTimeSource(hlc.Zero)
-					next, err := seqFixture.BestEffort.Wrap(fixture.Context, seqFixture.Core)
+					next, err := seqFixture.Staging.Wrap(fixture.Context, seqFixture.Core)
+					require.NoError(t, err)
+					next, err = seqFixture.BestEffort.Wrap(fixture.Context, next)
 					require.NoError(t, err)
 					return next
 				},

--- a/internal/sequencer/core/core.go
+++ b/internal/sequencer/core/core.go
@@ -37,25 +37,35 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// The Core sequencer accepts batches by writing them to a staging
-// table. It will then apply the data in a transactionally-consistent
-// and possibly concurrent fashion.
+// The Core sequencer applies transactional data read from a
+// [types.BatchReader].
+//
+// The Core sequencer applies transactions to the target database in a
+// concurrent manner, subject to [sequencer.Config.Parallelism]. The
+// reader is consumed by a [sequtil.Copier] to assemble a
+// [types.MultiBatch]. When the batch has reached the desired flush
+// size, it is assigned to a [round] and subsequently scheduled for
+// execution.
+//
+// Opportunities for concurrent execution are found by examining the
+// keys of the mutations to be applied to a target table. The enclosed
+// [scheduler.Scheduler] and its [lockset.Set] manage the active keys.
 type Core struct {
-	cfg         *sequencer.Config
-	leases      types.Leases
-	scheduler   *scheduler.Scheduler
-	stagers     types.Stagers
-	stagingPool *types.StagingPool
-	targetPool  *types.TargetPool
+	cfg        *sequencer.Config
+	leases     types.Leases
+	scheduler  *scheduler.Scheduler
+	targetPool *types.TargetPool
 }
 
 var _ sequencer.Sequencer = (*Core)(nil)
 
-// Start implements [sequencer.Sequencer]. It will incrementally unstage
-// and apply batches of mutations within the given bounds.
+// Start implements [sequencer.Sequencer].
 func (s *Core) Start(
 	ctx *stopper.Context, opts *sequencer.StartOptions,
 ) (types.MultiAcceptor, *notify.Var[sequencer.Stat], error) {
+	if opts.BatchReader == nil {
+		return nil, nil, errors.New("no BatchReader provided")
+	}
 	progress := notify.VarOf(sequencer.NewStat(opts.Group, &ident.TableMap[hlc.Range]{}))
 	grace := s.cfg.TaskGracePeriod
 	// Acquire a lease on the group name to prevent multiple sweepers
@@ -112,8 +122,17 @@ func (s *Core) Start(
 						}
 						_, _, _ = progress.Update(func(stat sequencer.Stat) (sequencer.Stat, error) {
 							stat = stat.Copy()
-							for _, table := range group.Tables {
-								stat.Progress().Put(table, advanceTo)
+							if len(group.Tables) == 0 {
+								// If the group defined no tables, we
+								// don't want to lose this update.
+								// Synthesize a fake table name from the
+								// group.
+								stat.Progress().Put(ident.NewTable(
+									group.Enclosing, group.Name), advanceTo)
+							} else {
+								for _, table := range group.Tables {
+									stat.Progress().Put(table, advanceTo)
+								}
 							}
 							return stat, nil
 						})
@@ -124,18 +143,12 @@ func (s *Core) Start(
 			}
 		})
 
-		// Open a reader over the staging tables. It will respond to
-		// updates in the timestamp bounds and provide a sequence of
-		// event notifications that are interpreted by a Copier below.
-		stagingReader, err := s.stagers.Read(ctx, &types.StagingQuery{
-			Bounds:       opts.Bounds,
-			FragmentSize: s.cfg.ScanSize,
-			Group:        group,
-		})
+		// Open a reader over async data.
+		batchCursors, err := opts.BatchReader.Read(ctx)
 		if err != nil {
 			log.WithError(err).Warnf(
-				"could not open staging table reader for %s; will retry",
-				group)
+				"could not open async reader for %s; will retry", group)
+			return
 		}
 
 		// We'll set up a template instance of round and then stamp out
@@ -153,7 +166,6 @@ func (s *Core) Start(
 			duration:    sweepDuration.WithLabelValues(metricLabels...),
 			lastAttempt: sweepLastAttempt.WithLabelValues(metricLabels...),
 			lastSuccess: sweepLastSuccess.WithLabelValues(metricLabels...),
-			skew:        sweepSkewCount.WithLabelValues(metricLabels...),
 		}
 		nextRound := func() *round {
 			cpy := *template
@@ -195,7 +207,7 @@ func (s *Core) Start(
 		// target.
 		copier := &sequtil.Copier{
 			Config: s.cfg,
-			Source: stagingReader,
+			Source: batchCursors,
 			// We'll get this callback when the copier does not expect
 			// any more data to arrive until the bounds are updated.
 			Progress: func(ctx *stopper.Context, progress hlc.Range) error {
@@ -312,5 +324,5 @@ func (s *Core) Start(
 			}
 		}
 	})
-	return &acceptor{s}, progress, nil
+	return &acceptor{}, progress, nil
 }

--- a/internal/sequencer/core/metrics.go
+++ b/internal/sequencer/core/metrics.go
@@ -44,8 +44,4 @@ var (
 		Name: "core_sweep_success_timestamp_seconds",
 		Help: "the wall time at which a sweep attempt last succeeded",
 	}, metrics.SchemaLabels)
-	sweepSkewCount = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "core_sweep_skew_count",
-		Help: "the number of times a target transaction committed, but the staging tx did not",
-	}, metrics.SchemaLabels)
 )

--- a/internal/sequencer/core/provider.go
+++ b/internal/sequencer/core/provider.go
@@ -31,16 +31,12 @@ func ProvideCore(
 	cfg *sequencer.Config,
 	leases types.Leases,
 	scheduler *scheduler.Scheduler,
-	stagers types.Stagers,
-	stagingPool *types.StagingPool,
 	targetPool *types.TargetPool,
 ) *Core {
 	return &Core{
-		cfg:         cfg,
-		leases:      leases,
-		scheduler:   scheduler,
-		stagers:     stagers,
-		stagingPool: stagingPool,
-		targetPool:  targetPool,
+		cfg:        cfg,
+		leases:     leases,
+		scheduler:  scheduler,
+		targetPool: targetPool,
 	}
 }

--- a/internal/sequencer/seqtest/wire_gen.go
+++ b/internal/sequencer/seqtest/wire_gen.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/replicator/internal/sequencer/retire"
 	"github.com/cockroachdb/replicator/internal/sequencer/scheduler"
 	script2 "github.com/cockroachdb/replicator/internal/sequencer/script"
+	"github.com/cockroachdb/replicator/internal/sequencer/staging"
 	"github.com/cockroachdb/replicator/internal/sequencer/switcher"
 	"github.com/cockroachdb/replicator/internal/sinktest/all"
 )
@@ -43,7 +44,7 @@ func NewSequencerFixture(fixture *all.Fixture, config *sequencer.Config, scriptC
 		return nil, err
 	}
 	targetPool := baseFixture.TargetPool
-	coreCore := core.ProvideCore(config, leases, schedulerScheduler, stagers, stagingPool, targetPool)
+	coreCore := core.ProvideCore(config, leases, schedulerScheduler, targetPool)
 	marker := decorators.ProvideMarker(stagingPool, stagers)
 	once := decorators.ProvideOnce(stagingPool, stagers)
 	retryTarget := decorators.ProvideRetryTarget(targetPool)
@@ -56,7 +57,8 @@ func NewSequencerFixture(fixture *all.Fixture, config *sequencer.Config, scriptC
 		return nil, err
 	}
 	scriptSequencer := script2.ProvideSequencer(loader, targetPool, watchers)
-	switcherSwitcher := switcher.ProvideSequencer(bestEffort, coreCore, diagnostics, immediateImmediate, stagingPool, targetPool)
+	stagingStaging := staging.ProvideStaging(config, marker, stagers, stagingPool)
+	switcherSwitcher := switcher.ProvideSequencer(bestEffort, coreCore, diagnostics, immediateImmediate, stagingStaging, stagingPool, targetPool)
 	seqtestFixture := &Fixture{
 		Fixture:    fixture,
 		BestEffort: bestEffort,
@@ -65,6 +67,7 @@ func NewSequencerFixture(fixture *all.Fixture, config *sequencer.Config, scriptC
 		Immediate:  immediateImmediate,
 		Retire:     retireRetire,
 		Script:     scriptSequencer,
+		Staging:    stagingStaging,
 		Switcher:   switcherSwitcher,
 	}
 	return seqtestFixture, nil

--- a/internal/sequencer/sequencer.go
+++ b/internal/sequencer/sequencer.go
@@ -59,6 +59,7 @@ type Shim interface {
 
 // StartOptions is passed to [Sequencer.Start].
 type StartOptions struct {
+	BatchReader types.BatchReader      // An asynchronous source of transactional data.
 	Bounds      *notify.Var[hlc.Range] // Control the range of eligible timestamps.
 	Delegate    types.MultiAcceptor    // The acceptor to use when continuing to process mutations.
 	Group       *types.TableGroup      // The tables that should be operated on.

--- a/internal/sequencer/sequtil/copier.go
+++ b/internal/sequencer/sequtil/copier.go
@@ -43,15 +43,15 @@ type FlushFn func(ctx *stopper.Context, batch *types.MultiBatch, fragment bool) 
 // ProgressFn is a callback from a [Copier].
 type ProgressFn func(ctx *stopper.Context, progress hlc.Range) error
 
-// A Copier consumes a channel of [types.StagingCursor], assembles the
+// A Copier consumes a channel of [types.BatchCursor], assembles the
 // individual temporal batches into large batches, and invokes event
 // callbacks to process the larger batches.
 type Copier struct {
-	Config   *sequencer.Config           // Controls for flush behavior.
-	Each     EachFn                      // Optional callback to receive each batch.
-	Flush    FlushFn                     // Optional callback to receive aggregated data.
-	Progress ProgressFn                  // Optional callback when the source has become idle.
-	Source   <-chan *types.StagingCursor // Input data.
+	Config   *sequencer.Config         // Controls for flush behavior.
+	Each     EachFn                    // Optional callback to receive each batch.
+	Flush    FlushFn                   // Optional callback to receive aggregated data.
+	Progress ProgressFn                // Optional callback when the source has become idle.
+	Source   <-chan *types.BatchCursor // Input data.
 }
 
 // Run copies data from the source to the target. It is a blocking call

--- a/internal/sequencer/staging/acceptor.go
+++ b/internal/sequencer/staging/acceptor.go
@@ -1,0 +1,78 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package staging
+
+import (
+	"context"
+
+	"github.com/cockroachdb/replicator/internal/types"
+	"github.com/cockroachdb/replicator/internal/util/hlc"
+	"github.com/cockroachdb/replicator/internal/util/ident"
+	"github.com/cockroachdb/replicator/internal/util/retry"
+)
+
+// An acceptor writes incoming data to staging.
+type acceptor struct {
+	*Staging
+}
+
+var _ types.MultiAcceptor = (*acceptor)(nil)
+
+// AcceptMultiBatch implements [types.MultiAcceptor] and processes the
+// batch in time order.
+func (a *acceptor) AcceptMultiBatch(
+	ctx context.Context, batch *types.MultiBatch, opts *types.AcceptOptions,
+) error {
+	// Coalesce for better database interaction.
+	mutsByTable := types.FlattenByTable[*types.MultiBatch](batch)
+
+	return mutsByTable.Range(func(tbl ident.Table, muts []types.Mutation) error {
+		stager, err := a.stagers.Get(ctx, tbl)
+		if err != nil {
+			return err
+		}
+		return retry.Retry(ctx, a.stagingPool, func(ctx context.Context) error {
+			return stager.Stage(ctx, a.stagingPool, muts)
+		})
+	})
+}
+
+// AcceptTableBatch implements [types.TableAcceptor].
+func (a *acceptor) AcceptTableBatch(
+	ctx context.Context, batch *types.TableBatch, opts *types.AcceptOptions,
+) error {
+	stager, err := a.stagers.Get(ctx, batch.Table)
+	if err != nil {
+		return err
+	}
+	return retry.Retry(ctx, a.stagingPool, func(ctx context.Context) error {
+		return stager.Stage(ctx, a.stagingPool, batch.Data)
+	})
+}
+
+// AcceptTemporalBatch implements [types.MultiAcceptor]. This does not
+// impose any per-table ordering, since the staging tables have no order
+// requirements.
+func (a *acceptor) AcceptTemporalBatch(
+	ctx context.Context, batch *types.TemporalBatch, opts *types.AcceptOptions,
+) error {
+	multi := &types.MultiBatch{
+		Data:   []*types.TemporalBatch{batch},
+		ByTime: map[hlc.Time]*types.TemporalBatch{batch.Time: batch},
+	}
+	return a.AcceptMultiBatch(ctx, multi, opts)
+}

--- a/internal/sequencer/staging/provider.go
+++ b/internal/sequencer/staging/provider.go
@@ -14,24 +14,29 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package core_test
+package staging
 
 import (
-	"testing"
-
 	"github.com/cockroachdb/replicator/internal/sequencer"
-	"github.com/cockroachdb/replicator/internal/sequencer/seqtest"
-	"github.com/cockroachdb/replicator/internal/sinktest/all"
+	"github.com/cockroachdb/replicator/internal/sequencer/decorators"
+	"github.com/cockroachdb/replicator/internal/types"
+	"github.com/google/wire"
 )
 
-func TestCore(t *testing.T) {
-	seqtest.CheckSequencer(t,
-		&all.WorkloadConfig{
-			DisableAcceptor: true,
-			DisableStaging:  true,
-		},
-		func(t *testing.T, fixture *all.Fixture, seqFixture *seqtest.Fixture) sequencer.Sequencer {
-			return seqFixture.Core
-		},
-		func(t *testing.T, check *seqtest.Check) {})
+// Set is used by Wire.
+var Set = wire.NewSet(ProvideStaging)
+
+// ProvideStaging is called by Wire.
+func ProvideStaging(
+	cfg *sequencer.Config,
+	markers *decorators.Marker,
+	stagers types.Stagers,
+	stagingPool *types.StagingPool,
+) *Staging {
+	return &Staging{
+		cfg:         cfg,
+		markers:     markers,
+		stagers:     stagers,
+		stagingPool: stagingPool,
+	}
 }

--- a/internal/sequencer/staging/staging.go
+++ b/internal/sequencer/staging/staging.go
@@ -1,0 +1,74 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package staging contains a [sequencer.Shim] that writes incoming
+// mutations to staging.
+package staging
+
+import (
+	"github.com/cockroachdb/field-eng-powertools/notify"
+	"github.com/cockroachdb/field-eng-powertools/stopper"
+	"github.com/cockroachdb/replicator/internal/sequencer"
+	"github.com/cockroachdb/replicator/internal/sequencer/decorators"
+	"github.com/cockroachdb/replicator/internal/types"
+)
+
+// Staging is a [sequencer.Shim] that returns an acceptor that writes
+// incoming data to staging tables.
+type Staging struct {
+	cfg         *sequencer.Config
+	markers     *decorators.Marker
+	stagers     types.Stagers
+	stagingPool *types.StagingPool
+}
+
+var _ sequencer.Shim = (*Staging)(nil)
+
+// Wrap implements [sequencer.Shim].
+func (s *Staging) Wrap(
+	_ *stopper.Context, delegate sequencer.Sequencer,
+) (sequencer.Sequencer, error) {
+	return &staging{s, delegate}, nil
+}
+
+type staging struct {
+	*Staging
+	delegate sequencer.Sequencer
+}
+
+var _ sequencer.Sequencer = (*staging)(nil)
+
+// Start injects a staging-table query as an asynchronous data source to
+// be passed into the next (core) sequencer.
+func (s *staging) Start(
+	ctx *stopper.Context, opts *sequencer.StartOptions,
+) (types.MultiAcceptor, *notify.Var[sequencer.Stat], error) {
+	reader, err := s.stagers.Query(ctx, &types.StagingQuery{
+		Bounds:       opts.Bounds,
+		FragmentSize: s.cfg.ScanSize,
+		Group:        opts.Group,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	opts = opts.Copy()
+	opts.BatchReader = reader
+	opts.Delegate = s.markers.MultiAcceptor(opts.Delegate)
+
+	_, stats, err := s.delegate.Start(ctx, opts)
+	return &acceptor{s.Staging}, stats, err
+}

--- a/internal/sequencer/staging/staging_test.go
+++ b/internal/sequencer/staging/staging_test.go
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package core_test
+package staging_test
 
 import (
 	"testing"
@@ -22,16 +22,15 @@ import (
 	"github.com/cockroachdb/replicator/internal/sequencer"
 	"github.com/cockroachdb/replicator/internal/sequencer/seqtest"
 	"github.com/cockroachdb/replicator/internal/sinktest/all"
+	"github.com/stretchr/testify/require"
 )
 
-func TestCore(t *testing.T) {
-	seqtest.CheckSequencer(t,
-		&all.WorkloadConfig{
-			DisableAcceptor: true,
-			DisableStaging:  true,
-		},
+func TestStaging(t *testing.T) {
+	seqtest.CheckSequencer(t, &all.WorkloadConfig{},
 		func(t *testing.T, fixture *all.Fixture, seqFixture *seqtest.Fixture) sequencer.Sequencer {
-			return seqFixture.Core
+			seq, err := seqFixture.Staging.Wrap(fixture.Context, seqFixture.Core)
+			require.NoError(t, err)
+			return seq
 		},
 		func(t *testing.T, check *seqtest.Check) {})
 }

--- a/internal/sequencer/switcher/provider.go
+++ b/internal/sequencer/switcher/provider.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/replicator/internal/sequencer/immediate"
 	"github.com/cockroachdb/replicator/internal/sequencer/scheduler"
 	"github.com/cockroachdb/replicator/internal/sequencer/script"
+	"github.com/cockroachdb/replicator/internal/sequencer/staging"
 	"github.com/cockroachdb/replicator/internal/types"
 	"github.com/cockroachdb/replicator/internal/util/diag"
 	"github.com/google/wire"
@@ -38,6 +39,7 @@ var Set = wire.NewSet(
 	decorators.Set,
 	script.Set,
 	scheduler.Set,
+	staging.Set,
 
 	ProvideSequencer,
 )
@@ -48,6 +50,7 @@ func ProvideSequencer(
 	core *core.Core,
 	diags *diag.Diagnostics,
 	imm *immediate.Immediate,
+	stg *staging.Staging,
 	stagingPool *types.StagingPool,
 	targetPool *types.TargetPool,
 ) *Switcher {
@@ -56,6 +59,7 @@ func ProvideSequencer(
 		core:        core,
 		diags:       diags,
 		immediate:   imm,
+		staging:     stg,
 		stagingPool: stagingPool,
 		targetPool:  targetPool,
 	}

--- a/internal/sequencer/switcher/switcher.go
+++ b/internal/sequencer/switcher/switcher.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/replicator/internal/sequencer/besteffort"
 	"github.com/cockroachdb/replicator/internal/sequencer/core"
 	"github.com/cockroachdb/replicator/internal/sequencer/immediate"
+	"github.com/cockroachdb/replicator/internal/sequencer/staging"
 	"github.com/cockroachdb/replicator/internal/types"
 	"github.com/cockroachdb/replicator/internal/util/diag"
 	"github.com/pkg/errors"
@@ -55,6 +56,7 @@ type Switcher struct {
 	core        *core.Core
 	diags       *diag.Diagnostics
 	immediate   *immediate.Immediate
+	staging     *staging.Staging
 	stagingPool *types.StagingPool
 	targetPool  *types.TargetPool
 

--- a/internal/sinktest/all/fixture.go
+++ b/internal/sinktest/all/fixture.go
@@ -127,7 +127,11 @@ func (f *Fixture) ReadStagingQuery(
 	stop := stopper.WithContext(ctx)
 	defer stop.Stop(0)
 
-	ch, err := f.Stagers.Read(stop, q)
+	reader, err := f.Stagers.Query(stop, q)
+	if err != nil {
+		return nil, err
+	}
+	ch, err := reader.Read(stop)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sinktest/all/workload.go
+++ b/internal/sinktest/all/workload.go
@@ -43,8 +43,10 @@ type Workload struct {
 // WorkloadConfig provides additional parameters to
 // [Fixture.NewWorkload].
 type WorkloadConfig struct {
-	DisableFK      bool // Don't create FK references from child to parent.
-	DisableStaging bool // Don't run any tests that involve the staging tables.
+	DisableAcceptor bool // Use BatchReader only.
+	DisableFK       bool // Don't create FK references from child to parent.
+	DisableFragment bool // Don't break transactions across multiple messages.
+	DisableStaging  bool // Don't run any tests that involve the staging tables.
 }
 
 // NewWorkload constructs a parent/child workload test rig attached to

--- a/internal/source/cdc/server/wire_gen.go
+++ b/internal/source/cdc/server/wire_gen.go
@@ -17,10 +17,11 @@ import (
 	"github.com/cockroachdb/replicator/internal/sequencer/retire"
 	"github.com/cockroachdb/replicator/internal/sequencer/scheduler"
 	script2 "github.com/cockroachdb/replicator/internal/sequencer/script"
+	"github.com/cockroachdb/replicator/internal/sequencer/staging"
 	"github.com/cockroachdb/replicator/internal/sequencer/switcher"
 	"github.com/cockroachdb/replicator/internal/sinkprod"
 	"github.com/cockroachdb/replicator/internal/source/cdc"
-	"github.com/cockroachdb/replicator/internal/staging"
+	staging2 "github.com/cockroachdb/replicator/internal/staging"
 	"github.com/cockroachdb/replicator/internal/staging/checkpoint"
 	"github.com/cockroachdb/replicator/internal/staging/leases"
 	"github.com/cockroachdb/replicator/internal/staging/memo"
@@ -122,12 +123,13 @@ func NewServer(ctx *stopper.Context, config *Config) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
-	coreCore := core.ProvideCore(sequencerConfig, typesLeases, schedulerScheduler, stagers, stagingPool, targetPool)
+	coreCore := core.ProvideCore(sequencerConfig, typesLeases, schedulerScheduler, targetPool)
 	marker := decorators.ProvideMarker(stagingPool, stagers)
 	once := decorators.ProvideOnce(stagingPool, stagers)
 	retryTarget := decorators.ProvideRetryTarget(targetPool)
 	immediateImmediate := immediate.ProvideImmediate(sequencerConfig, targetPool, marker, once, retryTarget, stagers)
-	switcherSwitcher := switcher.ProvideSequencer(bestEffort, coreCore, diagnostics, immediateImmediate, stagingPool, targetPool)
+	stagingStaging := staging.ProvideStaging(sequencerConfig, marker, stagers, stagingPool)
+	switcherSwitcher := switcher.ProvideSequencer(bestEffort, coreCore, diagnostics, immediateImmediate, stagingStaging, stagingPool, targetPool)
 	conveyors, err := conveyor.ProvideConveyors(ctx, acceptor, conveyorConfig, checkpoints, sequencer, retireRetire, switcherSwitcher, watchers)
 	if err != nil {
 		return nil, err
@@ -232,12 +234,13 @@ func newTestFixture(context *stopper.Context, config *Config) (*testFixture, fun
 	if err != nil {
 		return nil, nil, err
 	}
-	coreCore := core.ProvideCore(sequencerConfig, typesLeases, schedulerScheduler, stagers, stagingPool, targetPool)
+	coreCore := core.ProvideCore(sequencerConfig, typesLeases, schedulerScheduler, targetPool)
 	marker := decorators.ProvideMarker(stagingPool, stagers)
 	once := decorators.ProvideOnce(stagingPool, stagers)
 	retryTarget := decorators.ProvideRetryTarget(targetPool)
 	immediateImmediate := immediate.ProvideImmediate(sequencerConfig, targetPool, marker, once, retryTarget, stagers)
-	switcherSwitcher := switcher.ProvideSequencer(bestEffort, coreCore, diagnostics, immediateImmediate, stagingPool, targetPool)
+	stagingStaging := staging.ProvideStaging(sequencerConfig, marker, stagers, stagingPool)
+	switcherSwitcher := switcher.ProvideSequencer(bestEffort, coreCore, diagnostics, immediateImmediate, stagingStaging, stagingPool, targetPool)
 	conveyors, err := conveyor.ProvideConveyors(context, acceptor, conveyorConfig, checkpoints, sequencer, retireRetire, switcherSwitcher, watchers)
 	if err != nil {
 		return nil, nil, err
@@ -271,7 +274,7 @@ func newTestFixture(context *stopper.Context, config *Config) (*testFixture, fun
 // injector.go:
 
 var completeSet = wire.NewSet(
-	Set, cdc.Set, diag.New, retire.Set, script.Set, sinkprod.Set, staging.Set, switcher.Set, target.Set,
+	Set, cdc.Set, diag.New, retire.Set, script.Set, sinkprod.Set, staging2.Set, switcher.Set, target.Set,
 )
 
 // test_fixture.go:

--- a/internal/source/cdc/wire_gen.go
+++ b/internal/source/cdc/wire_gen.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/replicator/internal/sequencer/retire"
 	"github.com/cockroachdb/replicator/internal/sequencer/scheduler"
 	script2 "github.com/cockroachdb/replicator/internal/sequencer/script"
+	"github.com/cockroachdb/replicator/internal/sequencer/staging"
 	"github.com/cockroachdb/replicator/internal/sequencer/switcher"
 	"github.com/cockroachdb/replicator/internal/sinktest/all"
 	"github.com/cockroachdb/replicator/internal/staging/checkpoint"
@@ -78,12 +79,13 @@ func newTestFixture(fixture *all.Fixture, config *Config) (*testFixture, error) 
 	if err != nil {
 		return nil, err
 	}
-	coreCore := core.ProvideCore(sequencerConfig, typesLeases, schedulerScheduler, stagers, stagingPool, targetPool)
+	coreCore := core.ProvideCore(sequencerConfig, typesLeases, schedulerScheduler, targetPool)
 	marker := decorators.ProvideMarker(stagingPool, stagers)
 	once := decorators.ProvideOnce(stagingPool, stagers)
 	retryTarget := decorators.ProvideRetryTarget(targetPool)
 	immediateImmediate := immediate.ProvideImmediate(sequencerConfig, targetPool, marker, once, retryTarget, stagers)
-	switcherSwitcher := switcher.ProvideSequencer(bestEffort, coreCore, diagnostics, immediateImmediate, stagingPool, targetPool)
+	stagingStaging := staging.ProvideStaging(sequencerConfig, marker, stagers, stagingPool)
+	switcherSwitcher := switcher.ProvideSequencer(bestEffort, coreCore, diagnostics, immediateImmediate, stagingStaging, stagingPool, targetPool)
 	conveyors, err := conveyor.ProvideConveyors(context, acceptor, conveyorConfig, checkpoints, sequencer, retireRetire, switcherSwitcher, watchers)
 	if err != nil {
 		return nil, err

--- a/internal/source/kafka/wire_gen.go
+++ b/internal/source/kafka/wire_gen.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/replicator/internal/sequencer/retire"
 	"github.com/cockroachdb/replicator/internal/sequencer/scheduler"
 	script2 "github.com/cockroachdb/replicator/internal/sequencer/script"
+	"github.com/cockroachdb/replicator/internal/sequencer/staging"
 	"github.com/cockroachdb/replicator/internal/sequencer/switcher"
 	"github.com/cockroachdb/replicator/internal/sinkprod"
 	"github.com/cockroachdb/replicator/internal/staging/checkpoint"
@@ -104,12 +105,13 @@ func Start(ctx *stopper.Context, config *Config) (*Kafka, error) {
 	if err != nil {
 		return nil, err
 	}
-	coreCore := core.ProvideCore(sequencerConfig, typesLeases, schedulerScheduler, stagers, stagingPool, targetPool)
+	coreCore := core.ProvideCore(sequencerConfig, typesLeases, schedulerScheduler, targetPool)
 	marker := decorators.ProvideMarker(stagingPool, stagers)
 	once := decorators.ProvideOnce(stagingPool, stagers)
 	retryTarget := decorators.ProvideRetryTarget(targetPool)
 	immediateImmediate := immediate.ProvideImmediate(sequencerConfig, targetPool, marker, once, retryTarget, stagers)
-	switcherSwitcher := switcher.ProvideSequencer(bestEffort, coreCore, diagnostics, immediateImmediate, stagingPool, targetPool)
+	stagingStaging := staging.ProvideStaging(sequencerConfig, marker, stagers, stagingPool)
+	switcherSwitcher := switcher.ProvideSequencer(bestEffort, coreCore, diagnostics, immediateImmediate, stagingStaging, stagingPool, targetPool)
 	conveyors, err := conveyor.ProvideConveyors(ctx, acceptor, conveyorConfig, checkpoints, sequencer, retireRetire, switcherSwitcher, watchers)
 	if err != nil {
 		return nil, err

--- a/internal/source/objstore/wire_gen.go
+++ b/internal/source/objstore/wire_gen.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/replicator/internal/sequencer/retire"
 	"github.com/cockroachdb/replicator/internal/sequencer/scheduler"
 	script2 "github.com/cockroachdb/replicator/internal/sequencer/script"
+	"github.com/cockroachdb/replicator/internal/sequencer/staging"
 	"github.com/cockroachdb/replicator/internal/sequencer/switcher"
 	"github.com/cockroachdb/replicator/internal/sinkprod"
 	"github.com/cockroachdb/replicator/internal/staging/checkpoint"
@@ -103,12 +104,13 @@ func Start(ctx *stopper.Context, config *Config) (*Objstore, error) {
 	if err != nil {
 		return nil, err
 	}
-	coreCore := core.ProvideCore(sequencerConfig, typesLeases, schedulerScheduler, stagers, stagingPool, targetPool)
+	coreCore := core.ProvideCore(sequencerConfig, typesLeases, schedulerScheduler, targetPool)
 	marker := decorators.ProvideMarker(stagingPool, stagers)
 	once := decorators.ProvideOnce(stagingPool, stagers)
 	retryTarget := decorators.ProvideRetryTarget(targetPool)
 	immediateImmediate := immediate.ProvideImmediate(sequencerConfig, targetPool, marker, once, retryTarget, stagers)
-	switcherSwitcher := switcher.ProvideSequencer(bestEffort, coreCore, diagnostics, immediateImmediate, stagingPool, targetPool)
+	stagingStaging := staging.ProvideStaging(sequencerConfig, marker, stagers, stagingPool)
+	switcherSwitcher := switcher.ProvideSequencer(bestEffort, coreCore, diagnostics, immediateImmediate, stagingStaging, stagingPool, targetPool)
 	conveyors, err := conveyor.ProvideConveyors(ctx, acceptor, conveyorConfig, checkpoints, sequencer, retireRetire, switcherSwitcher, watchers)
 	if err != nil {
 		return nil, err

--- a/internal/staging/stage/table_merger_test.go
+++ b/internal/staging/stage/table_merger_test.go
@@ -117,7 +117,7 @@ func TestTableMerger(t *testing.T) {
 		})
 	}
 
-	out := make(chan *types.StagingCursor)
+	out := make(chan *types.BatchCursor)
 	merge := newTableMerger(&types.TableGroup{
 		Name:      ident.New("testing"),
 		Enclosing: fixture.TargetSchema.Schema(),

--- a/internal/types/batch_reader.go
+++ b/internal/types/batch_reader.go
@@ -1,0 +1,91 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/field-eng-powertools/stopper"
+	"github.com/cockroachdb/replicator/internal/util/hlc"
+)
+
+// BatchCursor is emitted by [BatchReader.Read].
+type BatchCursor struct {
+	// A batch of data, corresponding to a transaction in the source
+	// database. This may be nil for a progress-only update.
+	Batch *TemporalBatch
+
+	// This field will be populated if the reader encounters an
+	// unrecoverable error while processing. A result containing an
+	// error will be the final message in the channel before it is
+	// closed.
+	Error error
+
+	// Fragment will be set if the Batch is not guaranteed to contain
+	// all data for its given timestamp. This will occur, for example,
+	// if the number of mutations for the timestamp exceeds
+	// [StagingQuery.FragmentSize] or if an underlying database query is
+	// not guaranteed to have yet read all values at the batch's
+	// time (e.g. scan boundary alignment). Consumers that require
+	// transactionally-consistent views of the data should wait for the
+	// next, non-fragmented, cursor update.
+	Fragment bool
+
+	// Jump indicates that the scanning bounds changed such that the
+	// data in the stream may be disjoint.
+	Jump bool
+
+	// Progress indicates the range of data which has been successfully
+	// scanned so far. Receivers may encounter progress-only updates
+	// which happen when the end of the scanned bounds have been reached
+	// or if there is a "pipeline bubble" when reading data from the
+	// staging tables.
+	Progress hlc.Range
+}
+
+// String is for debugging use only.
+func (c *BatchCursor) String() string {
+	var buf strings.Builder
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", " ")
+	if err := enc.Encode(c); err != nil {
+		return fmt.Sprintf("error: %v", err)
+	}
+	return buf.String()
+}
+
+// A BatchReader provides access to transactional data. Because this
+// can be a potentially expensive or otherwise unbounded amount of data,
+// the results are provided via a channel which may be incrementally
+// consumed from buffered data.
+type BatchReader interface {
+	// Read returns a channel that will emit transactional data.
+	// Implementations should be prepared to have Read called more than
+	// once on the same BatchReader instance. In this case, the reader
+	// should replay from an appropriate point.
+	//
+	// Care should be taken to [stopper.Context.Stop] the context passed
+	// into this method to prevent goroutine or database leaks. When the
+	// context is gracefully stopped, the channel will be closed
+	// normally.
+	//
+	// Any errors encountered while reading will be returned in the
+	// final message before closing the channel.
+	Read(ctx *stopper.Context) (<-chan *BatchCursor, error)
+}


### PR DESCRIPTION
This change allows the source of staging data provided to the Core sequencer to
be configured. The StagingCursor type is renamed to BatchCursor and a new
BatchReader interface defines a way to receive an asynchronous stream of cursors.

All existing code is updated to inject a Staging sequencer into the stack. This
sequencer provides an acceptor which writes incoming data to the staging tables
and injects the existing staging-reader implementation into Core.

The Core sequencer's acceptor is now a no-op. The workload checker is updated
to support providing data via BatchReader. This allows Core to be tested
without use of any staging tables.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/1019)
<!-- Reviewable:end -->
