### PR TITLE
workflows: Mark docker prune step as optional

### DIFF
--- a/.github/workflows/go-docker.yaml
+++ b/.github/workflows/go-docker.yaml
@@ -102,6 +102,9 @@ jobs:
     runs-on: ubuntu-latest
     needs:
      - docker
+    # This step can experience a query vs delete race if multiple builds
+    # run concurrently.
+    continue-on-error: true
     steps:
       - name: Prune untagged GHCR images
         uses: vlaurin/action-ghcr-prune@v0.6.0


### PR DESCRIPTION
The old-image cleanup can encounter a race condition between finding stale images and deleting them if multiple builds run concurrently. This is not a criticial build step, so we'll allow it to fail.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/1024)
<!-- Reviewable:end -->
