### PR TITLE
conveyor: Revise source_lag_seconds description

### DIFF
--- a/internal/conveyor/metrics.go
+++ b/internal/conveyor/metrics.go
@@ -36,7 +36,7 @@ var (
 	}, []string{"kind", "target"})
 	sourceLagDuration = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "source_lag_seconds",
-		Help: "the age of the data received from the source changefeed",
+		Help: "the age of the most recently received checkpoint",
 	}, []string{"kind", "target"})
 	targetLagDuration = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "target_lag_seconds",


### PR DESCRIPTION
The previous description implied that this metric tracks the age of the mutations, when, in fact, it tracks the age of checkpoints (resolved timestamps).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/1025)
<!-- Reviewable:end -->
