### PR TITLE
replicator: Use iterators instead of Range callbacks.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@
 #
 # The go compiler will run using the host architecture, but
 # cross-compile to the desired target platform given to buildx.
-FROM --platform=$BUILDPLATFORM golang:1.22 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23 AS builder
 WORKDIR /tmp/compile
 ARG TARGETOS TARGETARCH
 RUN --mount=target=. \
@@ -29,7 +29,7 @@ RUN --mount=target=. \
 
 # This is a cgo build, which make cross-compilation non-trivial. The
 # only use case that we need to support at the moment is linux/amd64.
-FROM --platform=$TARGETPLATFORM golang:1.22 AS builder-cgo
+FROM --platform=$TARGETPLATFORM golang:1.23 AS builder-cgo
 WORKDIR /tmp/compile
 ARG TARGETOS TARGETARCH
 RUN --mount=type=cache,target=/var/cache/apt \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/cockroachdb/replicator
 
-go 1.22.6
+go 1.23.0
+
+toolchain go1.23.1
 
 require (
 	github.com/IBM/sarama v1.43.3

--- a/internal/conveyor/conveyor.go
+++ b/internal/conveyor/conveyor.go
@@ -79,10 +79,9 @@ func (c *Conveyors) Get(schema ident.Schema) (*Conveyor, error) {
 		return nil, err
 	}
 	var tables []ident.Table
-	_ = w.Get().Columns.Range(func(tbl ident.Table, _ []types.ColData) error {
+	for tbl := range w.Get().Columns.Keys() {
 		tables = append(tables, tbl)
-		return nil
-	})
+	}
 
 	tableGroup := &types.TableGroup{
 		Enclosing: schema,

--- a/internal/script/bag_wrapper.go
+++ b/internal/script/bag_wrapper.go
@@ -60,11 +60,9 @@ func (m *bagWrapper) Has(key string) bool {
 // Keys implements goja.DynamicObject.
 func (m *bagWrapper) Keys() []string {
 	ret := make([]string, 0, m.data.Len())
-	// Ignoring error since callback returns nil.
-	_ = m.data.Range(func(k ident.Ident, v any) error {
+	for k := range m.data.Keys() {
 		ret = append(ret, k.Raw())
-		return nil
-	})
+	}
 	return ret
 }
 

--- a/internal/script/loader.go
+++ b/internal/script/loader.go
@@ -211,9 +211,11 @@ func (l *Loader) Bind(
 		l.diags.Unregister(diagName)
 	})
 
-	err = ret.Targets.Range(func(tbl ident.Table, tblCfg *Target) error {
-		return errors.Wrap(l.applyConfigs.Set(tbl, &tblCfg.Config), tbl.Raw())
-	})
+	for tbl, tblCfg := range ret.Targets.All() {
+		if err := l.applyConfigs.Set(tbl, &tblCfg.Config); err != nil {
+			return nil, errors.Wrap(err, tbl.Raw())
+		}
+	}
 
 	return ret, err
 }

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -442,12 +442,11 @@ func (s *UserScript) bindDeletesToFunction(fnName string, deletesTo deletesToJS)
 		}
 
 		// Ensure that any emitted mutation will be a deletion.
-		_ = dispatched.Range(func(_ ident.Table, muts []types.Mutation) error {
+		for muts := range dispatched.Values() {
 			for idx := range muts {
 				muts[idx].Deletion = true
 			}
-			return nil
-		})
+		}
 
 		return dispatched, nil
 	}

--- a/internal/sequencer/core/round.go
+++ b/internal/sequencer/core/round.go
@@ -70,7 +70,7 @@ func (r *round) accumulate(segment *types.MultiBatch) error {
 		r.batch = segment
 		return nil
 	}
-	return segment.CopyInto(r.batch)
+	return types.Apply(segment.Mutations(), r.batch.Accumulate)
 }
 
 // scheduleCommit handles the error-retry logic around tryCommit.

--- a/internal/sequencer/scheduler/scheduler.go
+++ b/internal/sequencer/scheduler/scheduler.go
@@ -111,11 +111,10 @@ func keyForSingleton(table ident.Table, mut types.Mutation) []string {
 }
 
 // keyForBatch creates a locking set for all rows within the batch.
-func keyForBatch[B any](batch types.Batch[B]) []string {
+func keyForBatch[B types.Batch[B]](batch B) []string {
 	var ret []string
-	_ = batch.CopyInto(types.AccumulatorFunc(func(table ident.Table, mut types.Mutation) error {
+	for table, mut := range batch.Mutations() {
 		ret = append(ret, keyForSingleton(table, mut)...)
-		return nil
-	}))
+	}
 	return ret
 }

--- a/internal/sequencer/script/script.go
+++ b/internal/sequencer/script/script.go
@@ -19,14 +19,11 @@
 package script
 
 import (
-	"context"
-
 	"github.com/cockroachdb/field-eng-powertools/notify"
 	"github.com/cockroachdb/field-eng-powertools/stopper"
 	"github.com/cockroachdb/replicator/internal/script"
 	"github.com/cockroachdb/replicator/internal/sequencer"
 	"github.com/cockroachdb/replicator/internal/types"
-	"github.com/cockroachdb/replicator/internal/util/ident"
 )
 
 // Sequencer injects the userscript shim into a [sequencer.Sequencer]
@@ -97,14 +94,12 @@ func (w *wrapper) Start(
 	// to immediate mode, in which the sequencer caller won't
 	// necessarily have created a transaction.
 	ensureTX := false
-	// No interesting error returned from Range.
-	_ = scr.Targets.Range(func(_ ident.Table, target *script.Target) error {
+	for target := range scr.Targets.Values() {
 		if target.UserAcceptor != nil {
 			ensureTX = true
-			return context.Canceled // Arbitrary error to stop early.
+			break
 		}
-		return nil
-	})
+	}
 
 	// Install the target-phase acceptor into the options chain. This
 	// will be invoked for mutations which have passed through the

--- a/internal/sequencer/script/source_acceptor.go
+++ b/internal/sequencer/script/source_acceptor.go
@@ -62,10 +62,10 @@ func acceptBatch[B types.Batch[B]](
 ) error {
 	nextBatch := &types.MultiBatch{}
 
-	if err := batch.CopyInto(types.AccumulatorFunc(func(table ident.Table, mut types.Mutation) error {
-		return a.acceptOne(ctx, nextBatch, table, mut)
-	})); err != nil {
-		return err
+	for table, mut := range batch.Mutations() {
+		if err := a.acceptOne(ctx, nextBatch, table, mut); err != nil {
+			return err
+		}
 	}
 
 	// Calls to source.Dispatch may remove mutations.

--- a/internal/sequencer/script/source_acceptor.go
+++ b/internal/sequencer/script/source_acceptor.go
@@ -98,7 +98,7 @@ func (a *sourceAcceptor) acceptOne(
 		return err
 	}
 	// Push the mutations into the replacement batch.
-	if err := dispatched.Range(func(table ident.Table, muts []types.Mutation) error {
+	for table, muts := range dispatched.All() {
 		if table.Empty() {
 			return errors.Errorf("%s returned an empty table name", fnName)
 		}
@@ -112,12 +112,9 @@ func (a *sourceAcceptor) acceptOne(
 			// Preserve incoming timestamp.
 			dispatchedMut.Time = mutToDispatch.Time
 			if err := acc.Accumulate(table, dispatchedMut); err != nil {
-				return err
+				return errors.Wrap(err, a.group.Name.Raw())
 			}
 		}
-		return err
-	}); err != nil {
-		return errors.Wrap(err, a.group.Name.Raw())
 	}
 	return nil
 }

--- a/internal/sequencer/seqtest/check.go
+++ b/internal/sequencer/seqtest/check.go
@@ -292,13 +292,11 @@ func (c *Check) Check(ctx *stopper.Context, t testing.TB, cfg *all.WorkloadConfi
 			// instance receiving data behind our backs.
 			if c.Stage > 0 && rand.Float32() < c.Stage {
 				for _, temp := range fragment.Data {
-					r.NoError(temp.Data.Range(func(table ident.Table, batch *types.TableBatch) error {
+					for table, batch := range temp.Data.All() {
 						stager, err := c.Fixture.Stagers.Get(ctx, table)
-						if err != nil {
-							return err
-						}
-						return stager.Stage(ctx, c.Fixture.StagingPool, batch.Data)
-					}))
+						r.NoError(err)
+						r.NoError(stager.Stage(ctx, c.Fixture.StagingPool, batch.Data))
+					}
 				}
 				continue
 			}

--- a/internal/sequencer/sequtil/copier.go
+++ b/internal/sequencer/sequtil/copier.go
@@ -142,7 +142,7 @@ top:
 		}
 
 		// Accumulate data.
-		if err := batch.CopyInto(accumulator); err != nil {
+		if err := types.Apply(batch.Mutations(), accumulator.Accumulate); err != nil {
 			return nil, err
 		}
 		count += batch.Count()

--- a/internal/sequencer/sequtil/copier_test.go
+++ b/internal/sequencer/sequtil/copier_test.go
@@ -78,13 +78,11 @@ func TestCopier(t *testing.T) {
 
 	// Apply data to the staging table.
 	for _, temporal := range testData.Data {
-		r.NoError(temporal.Data.Range(func(table ident.Table, batch *types.TableBatch) error {
+		for table, batch := range temporal.Data.All() {
 			stager, err := fixture.Stagers.Get(ctx, table)
-			if err != nil {
-				return err
-			}
-			return stager.Stage(ctx, fixture.StagingPool, batch.Data)
-		}))
+			r.NoError(err)
+			r.NoError(stager.Stage(ctx, fixture.StagingPool, batch.Data))
+		}
 	}
 	log.Infof("staged data in %s", time.Since(now))
 	now = time.Now()
@@ -113,7 +111,7 @@ func TestCopier(t *testing.T) {
 		},
 	}
 	r.NoError(copier.Run(ctx))
-	a.Equal(types.Flatten[*types.MultiBatch](testData), types.Flatten[*types.MultiBatch](seen))
+	a.Equal(types.Flatten(testData), types.Flatten(seen))
 
 	log.Infof("read data in %s", time.Since(now))
 }

--- a/internal/sequencer/sequtil/copier_test.go
+++ b/internal/sequencer/sequtil/copier_test.go
@@ -101,7 +101,7 @@ func TestCopier(t *testing.T) {
 			return nil
 		},
 		Flush: func(ctx *stopper.Context, batch *types.MultiBatch, segment bool) error {
-			return batch.CopyInto(seen)
+			return types.Apply(batch.Mutations(), seen.Accumulate)
 		},
 		Progress: func(ctx *stopper.Context, progress hlc.Range) error {
 			if progress.MaxInclusive() == endTime {

--- a/internal/sinktest/all/fixture.go
+++ b/internal/sinktest/all/fixture.go
@@ -148,7 +148,7 @@ func (f *Fixture) ReadStagingQuery(
 			// Copy the data into our accumulator. The batch will be
 			// nil if there's a progress-only update.
 			if cursor.Batch != nil {
-				if err := cursor.Batch.CopyInto(ret); err != nil {
+				if err := types.Apply(cursor.Batch.Mutations(), ret.Accumulate); err != nil {
 					return nil, err
 				}
 			}

--- a/internal/sinktest/all/fixture.go
+++ b/internal/sinktest/all/fixture.go
@@ -114,7 +114,7 @@ func (f *Fixture) PeekStaged(
 	if err != nil {
 		return nil, err
 	}
-	return types.Flatten[*types.MultiBatch](batch), nil
+	return types.Flatten(batch), nil
 }
 
 // ReadStagingQuery executes the staging query, returning the complete

--- a/internal/source/cdc/webhook.go
+++ b/internal/source/cdc/webhook.go
@@ -51,8 +51,7 @@ type WebhookPayload struct {
 // NewWebhookPayload constructs a payload for the batch.
 func NewWebhookPayload(batch *types.MultiBatch) (*WebhookPayload, error) {
 	ret := &WebhookPayload{}
-	// Ignoring error since callback returns nil.
-	if err := batch.CopyInto(types.AccumulatorFunc(func(table ident.Table, mut types.Mutation) error {
+	for table, mut := range batch.Mutations() {
 		line := WebhookPayloadLine{
 			After:   mut.Data,
 			Before:  mut.Before,
@@ -66,9 +65,6 @@ func NewWebhookPayload(batch *types.MultiBatch) (*WebhookPayload, error) {
 		}
 		ret.Payload = append(ret.Payload, line)
 		ret.Range = ret.Range.Extend(mut.Time)
-		return nil
-	})); err != nil {
-		return nil, err
 	}
 	ret.Length = len(ret.Payload)
 	return ret, nil

--- a/internal/source/kafka/integration_test.go
+++ b/internal/source/kafka/integration_test.go
@@ -419,8 +419,8 @@ func (p *kafkaProducer) writeBatch(batch *types.MultiBatch) error {
 		Updated string          `json:"updated"`
 	}
 	for _, b := range batch.Data {
-		for _, t := range b.Data.Entries() {
-			for _, v := range t.Value.Data {
+		for t := range b.Data.Values() {
+			for _, v := range t.Data {
 				msg := &payload{
 					After:   v.Data,
 					Before:  v.Before,
@@ -431,7 +431,7 @@ func (p *kafkaProducer) writeBatch(batch *types.MultiBatch) error {
 				if v.IsDelete() {
 					msg.After = nil
 				}
-				err := p.sendMessage(t.Value.Table.Raw(), -1, v.Key, msg)
+				err := p.sendMessage(t.Table.Raw(), -1, v.Key, msg)
 				if err != nil {
 					return err
 				}

--- a/internal/source/objstore/eventproc/local_test.go
+++ b/internal/source/objstore/eventproc/local_test.go
@@ -198,11 +198,9 @@ func TestLocalProcess(t *testing.T) {
 			// Make sure all the data in the batch has the correct table
 			for _, call := range tt.acceptor.Calls() {
 				for _, data := range call.Multi.Data {
-					data.Data.Range(
-						func(k ident.Table, v *types.TableBatch) error {
-							a.Equal(tt.wantTable, k)
-							return nil
-						})
+					for k := range data.Data.Keys() {
+						a.Equal(tt.wantTable, k)
+					}
 				}
 			}
 			// Verify timestamps.

--- a/internal/staging/stage/table_merger_test.go
+++ b/internal/staging/stage/table_merger_test.go
@@ -142,7 +142,7 @@ func TestTableMerger(t *testing.T) {
 				batch := cursor.Batch
 
 				if batch != nil {
-					seen = append(seen, types.Flatten[*types.TemporalBatch](batch)...)
+					seen = append(seen, types.Flatten(batch)...)
 
 					// The fragment bit will be set on boundary-aligned reads.
 					if batch.Time.Nanos()%fragmentSize == 0 {
@@ -186,7 +186,7 @@ func TestTableMerger(t *testing.T) {
 				batch := cursor.Batch
 				if batch != nil {
 
-					seen = append(seen, types.Flatten[*types.TemporalBatch](cursor.Batch)...)
+					seen = append(seen, types.Flatten(cursor.Batch)...)
 				}
 
 				// Ensure that time doesn't go backwards.

--- a/internal/staging/stage/table_reader_test.go
+++ b/internal/staging/stage/table_reader_test.go
@@ -122,7 +122,7 @@ func TestTableReader(t *testing.T) {
 					r.False(cursor.Fragment)
 				}
 
-				seen = append(seen, types.Flatten[*types.MultiBatch](cursor.Batch)...)
+				seen = append(seen, types.Flatten(cursor.Batch)...)
 				times = append(times, cursor.Progress.Min())
 
 				log.Infof("position %s vs %s", cursor.Progress, smallBatchEnd.Next())
@@ -189,7 +189,7 @@ func TestTableReader(t *testing.T) {
 				r.Len(cursor.Batch.Data, 1)
 				times[cursor.Batch.Data[0].Time] = struct{}{}
 
-				seen = append(seen, types.Flatten[*types.MultiBatch](cursor.Batch)...)
+				seen = append(seen, types.Flatten(cursor.Batch)...)
 
 				log.Infof("Progress %s", cursor.Progress)
 				if cursor.Progress.MaxInclusive() == bigTime {

--- a/internal/target/apply/column_mapping.go
+++ b/internal/target/apply/column_mapping.go
@@ -189,7 +189,7 @@ func newColumnMapping(
 
 	// We also allow the user to force non-existent columns to be
 	// ignored (e.g. to drop a column).
-	_ = cfg.Ignore.Range(func(tgt ident.Ident, _ bool) error {
+	for tgt := range cfg.Ignore.Keys() {
 		if _, alreadyIgnored := ret.Positions.Get(tgt); !alreadyIgnored {
 			ret.Ignore = append(ret.Ignore, tgt)
 			ret.Positions.Put(tgt, positionalColumn{
@@ -203,18 +203,14 @@ func newColumnMapping(
 				ValidityIndex: -1,
 			})
 		}
-		return nil
-	})
+	}
 
 	// Add redundant mappings for renamed columns.
-	if err := cfg.SourceNames.Range(func(tgt ident.Ident, src applycfg.SourceColumn) error {
+	for tgt, src := range cfg.SourceNames.All() {
 		ret.Renames.Put(src, tgt)
 		if found, ok := ret.Positions.Get(tgt); ok {
 			ret.Positions.Put(src, found)
 		}
-		return nil
-	}); err != nil {
-		return nil, err
 	}
 
 	return ret, nil

--- a/internal/target/apply/factory.go
+++ b/internal/target/apply/factory.go
@@ -52,12 +52,11 @@ func (f *factory) Diagnostic(_ context.Context) any {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
-	_ = f.mu.instances.Range(func(tbl ident.Table, impl *apply) error {
+	for tbl, impl := range f.mu.instances.All() {
 		impl.mu.RLock()
-		defer impl.mu.RUnlock()
 		ret.Put(tbl, impl.mu.templates.columnMapping)
-		return nil
-	})
+		impl.mu.RUnlock()
+	}
 
 	return ret
 }

--- a/internal/target/apply/queries/crdb/conditional.tmpl
+++ b/internal/target/apply/queries/crdb/conditional.tmpl
@@ -32,7 +32,7 @@ deadlined: filters the incoming data by the deadline columns
 
 deadlined AS (SELECT * from data WHERE ts > now() - '1m'::INTERVAL)
 */ -}}
-{{- $deadlineEntries := .Deadlines.Entries -}}
+{{- $deadlineEntries := deadlineEntries .Deadlines -}}
 {{- if $deadlineEntries -}}
 , {{- nl -}} {{- /* comma to terminate previous CTE clause. */ -}}
 deadlined AS (SELECT * FROM {{ $dataSource }} WHERE

--- a/internal/target/apply/queries/my/conditional.tmpl
+++ b/internal/target/apply/queries/my/conditional.tmpl
@@ -50,7 +50,7 @@ WITH data  ({{ template "names" .Columns }}) AS (
 deadlined: filters the incoming data by the deadline columns
 deadlined AS (SELECT * from data WHERE ts > now() - INTERVAL 1 second)
 */ -}}
-{{- $deadlineEntries := .Deadlines.Entries -}}
+{{- $deadlineEntries := deadlineEntries .Deadlines -}}
 {{- if $deadlineEntries -}}
 , {{- nl -}} {{- /* comma to terminate previous CTE clause. */ -}}
 deadlined AS (SELECT * FROM {{ $dataSource }} WHERE

--- a/internal/target/apply/queries/ora/upsert.tmpl
+++ b/internal/target/apply/queries/ora/upsert.tmpl
@@ -36,7 +36,7 @@ This is basically a SELECT * FROM data WHERE ts_col > (computed
 deadline). The computed deadline is the current time minus our
 time.Duration converted to some (fractional) seconds.
 */ -}}
-{{- $deadlineEntries := .Deadlines.Entries -}}
+{{- $deadlineEntries := deadlineEntries .Deadlines -}}
 {{- if $deadlineEntries -}}
     , {{- nl -}} {{- /* comma to terminate previous CTE clause. */ -}}
     deadlined AS (SELECT * FROM {{ $dataSource }} WHERE

--- a/internal/target/apply/queries/pg/conditional.tmpl
+++ b/internal/target/apply/queries/pg/conditional.tmpl
@@ -32,7 +32,7 @@ deadlined: filters the incoming data by the deadline columns
 
 deadlined AS (SELECT * from data WHERE ts > now() - '1m'::INTERVAL)
 */ -}}
-{{- $deadlineEntries := .Deadlines.Entries -}}
+{{- $deadlineEntries := deadlineEntries .Deadlines -}}
 {{- if $deadlineEntries -}}
 , {{- nl -}} {{- /* comma to terminate previous CTE clause. */ -}}
 deadlined AS (SELECT * FROM {{ $dataSource }} WHERE

--- a/internal/target/schemawatch/factory.go
+++ b/internal/target/schemawatch/factory.go
@@ -49,10 +49,9 @@ func (f *factory) Diagnostic(_ context.Context) any {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
-	_ = f.mu.data.Range(func(sch ident.Schema, w *watcher) error {
+	for sch, w := range f.mu.data.All() {
 		ret[sch.Raw()] = w.Get()
-		return nil
-	})
+	}
 
 	return ret
 }

--- a/internal/types/acceptors.go
+++ b/internal/types/acceptors.go
@@ -116,11 +116,10 @@ func (t *orderedAdapter) AcceptMultiBatch(
 ) error {
 	// Peek to find the current schema.
 	var commonSchema ident.Schema
-	_ = batch.CopyInto(AccumulatorFunc(func(table ident.Table, _ Mutation) error {
+	for table := range batch.Mutations() {
 		commonSchema = table.Schema()
-		// Just break the loop.
-		return context.Canceled
-	}))
+		break
+	}
 
 	// No mutations.
 	if commonSchema.Empty() {

--- a/internal/types/batches_test.go
+++ b/internal/types/batches_test.go
@@ -88,7 +88,9 @@ func testBatchInterface[B types.Batch[B]](t *testing.T, batch B) {
 	r.Zero(batch.Empty().Count())
 
 	acc := &types.MultiBatch{}
-	r.NoError(batch.CopyInto(acc))
+	for table, mut := range batch.Mutations() {
+		r.NoError(acc.Accumulate(table, mut))
+	}
 	r.Equal(batch.Count(), acc.Count())
 
 	flattened := types.Flatten(batch)

--- a/internal/types/batches_test.go
+++ b/internal/types/batches_test.go
@@ -91,6 +91,6 @@ func testBatchInterface[B types.Batch[B]](t *testing.T, batch B) {
 	r.NoError(batch.CopyInto(acc))
 	r.Equal(batch.Count(), acc.Count())
 
-	flattened := types.Flatten[B](batch)
+	flattened := types.Flatten(batch)
 	r.Equal(expected, flattened)
 }

--- a/internal/types/schema_data_test.go
+++ b/internal/types/schema_data_test.go
@@ -200,23 +200,21 @@ func TestSetComponents(t *testing.T) {
 		r.NoError(next.UnmarshalJSON(data))
 
 		r.Equal(sd.Columns.Len(), next.Columns.Len())
-		_ = sd.Columns.Range(func(table ident.Table, cols []ColData) error {
+		for table, cols := range sd.Columns.All() {
 			found := next.Columns.GetZero(table)
 			r.Len(found, len(cols))
 			for i := range cols {
 				r.True(cols[i].Equal(found[i]))
 			}
-			return nil
-		})
+		}
 		r.Equal(sd.Dependencies.Len(), next.Dependencies.Len())
-		_ = sd.Dependencies.Range(func(table ident.Table, deps []ident.Table) error {
+		for table, deps := range sd.Dependencies.All() {
 			found := next.Dependencies.GetZero(table)
 			r.Len(found, len(deps))
 			for i := range deps {
 				r.True(ident.Equal(deps[i], found[i]))
 			}
-			return nil
-		})
+		}
 	})
 
 	t.Run("check_cycle", func(t *testing.T) {

--- a/internal/util/applycfg/configs.go
+++ b/internal/util/applycfg/configs.go
@@ -42,12 +42,10 @@ func (c *Configs) Diagnostic(_ context.Context) any {
 	defer c.mu.RUnlock()
 
 	ret := &ident.TableMap[*Config]{}
-	// No error returned from callback.
-	_ = c.mu.data.Range(func(tbl ident.Table, v *notify.Var[*Config]) error {
+	for tbl, v := range c.mu.data.All() {
 		cfg, _ := v.Get()
 		ret.Put(tbl, cfg)
-		return nil
-	})
+	}
 
 	return ret
 }

--- a/internal/util/cdcjson/query_payload.go
+++ b/internal/util/cdcjson/query_payload.go
@@ -128,12 +128,12 @@ func (q *queryPayload) UnmarshalJSON(data []byte) error {
 	}
 	// Extract PK values.
 	q.keyValues = make([]json.RawMessage, q.keys.Len())
-	return q.keys.Range(func(k ident.Ident, pos int) error {
+	for k, pos := range q.keys.All() {
 		v, ok := msg.Get(k)
 		if !ok {
 			return errors.Errorf("missing primary key: %s", k)
 		}
 		q.keyValues[pos] = v
-		return nil
-	})
+	}
+	return nil
 }

--- a/internal/util/cmap/cmap_test.go
+++ b/internal/util/cmap/cmap_test.go
@@ -17,7 +17,8 @@
 package cmap
 
 import (
-	"sort"
+	"maps"
+	"slices"
 	"strconv"
 	"testing"
 
@@ -91,28 +92,13 @@ func TestMap(t *testing.T) {
 	r.True(ok)
 	r.Equal('R', found)
 
-	count := 0
-	r.NoError(m.Range(func(s string, r rune) error {
-		count++
-		return nil
-	}))
-	r.Equal(3, count)
+	r.Len(maps.Collect(m.All()), 3)
+	r.Len(slices.Collect(m.Keys()), 3)
+	r.Len(slices.Collect(m.Values()), 3)
 
 	cpy := New[string, int, rune](mapper)
 	m.CopyInto(cpy)
 	r.Equal(m.Len(), cpy.Len())
-
-	// Entries is not stable, since we don't require the C type to be
-	// ordered.
-	entries := m.Entries()
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].Key < entries[j].Key
-	})
-	r.Equal([]Entry[string, rune]{
-		{"001", 'R'},
-		{"2", '2'},
-		{"3", '3'},
-	}, entries)
 
 	// Verify delete.
 	m.Delete("00000001")

--- a/internal/util/cmap/equal.go
+++ b/internal/util/cmap/equal.go
@@ -16,10 +16,6 @@
 
 package cmap
 
-import "github.com/pkg/errors"
-
-var errStop = errors.New("sentinel")
-
 // Comparator returns a comparator for comparable types.
 func Comparator[C comparable]() func(C, C) bool {
 	return func(a C, b C) bool {
@@ -43,19 +39,15 @@ func Equal[K, V any](a, b Map[K, V], comparator func(V, V) bool) bool {
 		return false
 	}
 
-	ret := true
-	_ = a.Range(func(aK K, aV V) error {
+	for aK, aV := range a.All() {
 		bV, ok := b.Get(aK)
 		if !ok {
-			ret = false
-			return errStop
+			return false
 		}
 		if !comparator(aV, bV) {
-			ret = false
-			return errStop
+			return false
 		}
-		return nil
-	})
+	}
 
-	return ret
+	return true
 }

--- a/internal/util/cmap/identity.go
+++ b/internal/util/cmap/identity.go
@@ -16,7 +16,11 @@
 
 package cmap
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"iter"
+	"maps"
+)
 
 // NewIdentity returns a Map for comparable keys. A basic map type is
 // recommended unless compatibility with the Map interface is necessary.
@@ -25,6 +29,10 @@ func NewIdentity[K comparable, V any]() Map[K, V] {
 }
 
 type identity[K comparable, V any] map[K]V
+
+func (m identity[K, V]) All() iter.Seq2[K, V] {
+	return maps.All(m)
+}
 
 func (m identity[K, V]) CopyInto(dest Map[K, V]) {
 	for k, v := range m {
@@ -36,14 +44,6 @@ func (m identity[K, V]) Delete(key K) {
 	delete(m, key)
 }
 
-func (m identity[K, V]) Entries() []Entry[K, V] {
-	ret := make([]Entry[K, V], 0, len(m))
-	for k, v := range m {
-		ret = append(ret, Entry[K, V]{k, v})
-	}
-	return ret
-}
-
 func (m identity[K, V]) Get(key K) (_ V, ok bool) {
 	ret, ok := m[key]
 	return ret, ok
@@ -51,6 +51,10 @@ func (m identity[K, V]) Get(key K) (_ V, ok bool) {
 
 func (m identity[K, V]) GetZero(key K) V {
 	return m[key]
+}
+
+func (m identity[K, V]) Keys() iter.Seq[K] {
+	return maps.Keys(m)
 }
 
 func (m identity[K, V]) Len() int {
@@ -84,4 +88,8 @@ func (m identity[K, V]) MarshalJSON() ([]byte, error) {
 
 func (m identity[K, V]) UnmarshalJSON(buf []byte) error {
 	return json.Unmarshal(buf, &m)
+}
+
+func (m identity[K, V]) Values() iter.Seq[V] {
+	return maps.Values(m)
 }

--- a/internal/util/cmap/identity_test.go
+++ b/internal/util/cmap/identity_test.go
@@ -71,10 +71,9 @@ func TestIdentity(t *testing.T) {
 	r.False(ok)
 
 	count := 0
-	r.NoError(m.Range(func(s string, r rune) error {
+	for range m.All() {
 		count++
-		return nil
-	}))
+	}
 	r.Equal(3, count)
 
 	cpy := NewIdentity[string, rune]()

--- a/internal/util/merge/bag_validate.go
+++ b/internal/util/merge/bag_validate.go
@@ -31,13 +31,12 @@ func ValidateNoUnmappedColumns(bag *Bag) error {
 	}
 
 	var unexpectedCols strings.Builder
-	_ = bag.Unmapped.Range(func(name ident.Ident, _ any) error {
+	for name := range bag.Unmapped.Keys() {
 		if unexpectedCols.Len() > 0 {
 			unexpectedCols.WriteString(", ")
 		}
 		unexpectedCols.WriteString(name.Raw())
-		return nil
-	})
+	}
 	return errors.Errorf("unexpected columns: %s", unexpectedCols.String())
 }
 
@@ -63,12 +62,11 @@ func ValidatePK(bag *Bag) error {
 	}
 
 	var missingCols strings.Builder
-	_ = missingPKs.Range(func(name ident.Ident, _ struct{}) error {
+	for name := range missingPKs.Keys() {
 		if missingCols.Len() > 0 {
 			missingCols.WriteString(", ")
 		}
 		missingCols.WriteString(name.Raw())
-		return nil
-	})
+	}
 	return errors.Errorf("missing PK columns: %s", missingCols.String())
 }


### PR DESCRIPTION
This change replaces the Range callback functions with the new iterator type compatible with the range keyword in go 1.23.

The various map-like types receive iterator methods All(), Keys(), and Values(). The names of these methods are in line with the new iterator methods in the stdlib maps package. The Entries() and Range() methods are removed.

The apply templates were the only actual use of Entries(), which has been hoisted into a template helper function to support deadlined columns.

The net effect is to make flow-control more idiomatic. There were some cases where one would write "return nil" within a Range() callback when "continue" would be more natural or the use of "return sentinelError" when "break" would be the obvious choice. Many cases of always-nil error handling have been removed as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/1027)
<!-- Reviewable:end -->
