### PR TITLE
sequencer: updated the script test so that it uses the new GetRowWithPredicate method

### DIFF
--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cockroachdb/replicator/internal/sinktest"
 	"github.com/cockroachdb/replicator/internal/sinktest/all"
+	"github.com/cockroachdb/replicator/internal/sinktest/base"
 	"github.com/cockroachdb/replicator/internal/target/apply"
 	"github.com/cockroachdb/replicator/internal/types"
 	"github.com/cockroachdb/replicator/internal/util/applycfg"
@@ -403,10 +404,8 @@ CREATE TABLE %s.skewed_merge_times(
 		// Fix case for e.g. Oracle.
 		table, _ = fixture.Watcher.Get().OriginalName(table)
 		// Verify execution.
-		var count int
-		r.NoError(fixture.TargetPool.QueryRow(
-			fmt.Sprintf("SELECT count(*) FROM %s WHERE is_deleted = 1", table),
-		).Scan(&count))
+		count, err := base.GetRowCountWithPredicate(ctx, fixture.TargetPool, table, "is_deleted = 1")
+		r.NoError(err)
 		r.Equal(2, count)
 	})
 

--- a/internal/sequencer/script/script_test.go
+++ b/internal/sequencer/script/script_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/replicator/internal/sequencer/switcher"
 	"github.com/cockroachdb/replicator/internal/sinktest"
 	"github.com/cockroachdb/replicator/internal/sinktest/all"
+	"github.com/cockroachdb/replicator/internal/sinktest/base"
 	"github.com/cockroachdb/replicator/internal/types"
 	"github.com/cockroachdb/replicator/internal/util/hlc"
 	"github.com/cockroachdb/replicator/internal/util/ident"
@@ -134,11 +135,11 @@ api.configureTable("t_2", {
 	// Fake timestamps in use.
 	seqFixture.BestEffort.SetTimeSource(hlc.Zero)
 
-	base, err := seqFixture.SequencerFor(ctx, baseMode)
+	baseSeq, err := seqFixture.SequencerFor(ctx, baseMode)
 	r.NoError(err)
 
 	bounds := &notify.Var[hlc.Range]{}
-	wrapped, err := seqFixture.Script.Wrap(ctx, base)
+	wrapped, err := seqFixture.Script.Wrap(ctx, baseSeq)
 	r.NoError(err)
 	acc, stats, err := wrapped.Start(ctx, &sequencer.StartOptions{
 		Bounds:   bounds,
@@ -197,21 +198,8 @@ api.configureTable("t_2", {
 			search = "llebwoc"
 		}
 
-		// https://github.com/cockroachdb/replicator/issues/689
-		var q string
-		switch fixture.TargetPool.Product {
-		case types.ProductCockroachDB, types.ProductPostgreSQL:
-			q = "SELECT count(*) FROM %s WHERE v = $1"
-		case types.ProductMariaDB, types.ProductMySQL:
-			q = "SELECT count(*) FROM %s WHERE v = ?"
-		case types.ProductOracle:
-			q = "SELECT count(*) FROM %s WHERE v = :v"
-		default:
-			r.Fail("unimplemented product")
-		}
-
-		var count int
-		r.NoError(pool.QueryRowContext(ctx, fmt.Sprintf(q, tgt), search).Scan(&count))
+		count, err := base.GetRowCountWithPredicate(ctx, pool, tgt, fmt.Sprintf("v = '%s'", search))
+		r.NoError(err)
 		r.Equalf(numEmits, count, "in table %s", tgt)
 	}
 

--- a/internal/source/mylogical/integration_test.go
+++ b/internal/source/mylogical/integration_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/replicator/internal/sinkprod"
 	"github.com/cockroachdb/replicator/internal/sinktest"
 	"github.com/cockroachdb/replicator/internal/sinktest/all"
+	"github.com/cockroachdb/replicator/internal/sinktest/base"
 	"github.com/cockroachdb/replicator/internal/sinktest/scripttest"
 	"github.com/cockroachdb/replicator/internal/util/ident"
 	"github.com/cockroachdb/replicator/internal/util/stamp"
@@ -180,11 +181,8 @@ func testMYLogical(t *testing.T, fc *fixtureConfig) {
 	r.NoError(err)
 	// Wait for the update to propagate.
 	for {
-		var count int
-		if err := crdbPool.QueryRowContext(ctx,
-			fmt.Sprintf("SELECT count(*) FROM %s WHERE %s = 'updated'", tgt, crdbCol)).Scan(&count); !a.NoError(err) {
-			return
-		}
+		count, err := base.GetRowCountWithPredicate(ctx, fixture.TargetPool, tgt, fmt.Sprintf("%s = 'updated'", crdbCol))
+		r.NoError(err)
 		log.Trace("update count", count)
 		if count == rowCount {
 			break
@@ -205,11 +203,8 @@ func testMYLogical(t *testing.T, fc *fixtureConfig) {
 	r.NoError(err)
 	// Wait for the deletes to propagate.
 	for {
-		var count int
-		if err := crdbPool.QueryRowContext(ctx,
-			fmt.Sprintf("SELECT count(*) FROM %s WHERE %s = 'updated'", tgt, crdbCol)).Scan(&count); !a.NoError(err) {
-			return
-		}
+		count, err := base.GetRowCountWithPredicate(ctx, fixture.TargetPool, tgt, fmt.Sprintf("%s = 'updated'", crdbCol))
+		r.NoError(err)
 		log.Trace("delete count", count)
 		if count == rowCount-50 {
 			break

--- a/internal/source/pglogical/integration_test.go
+++ b/internal/source/pglogical/integration_test.go
@@ -257,11 +257,8 @@ func testPGLogical(t *testing.T, fc *fixtureConfig) {
 	// Wait for the update to propagate.
 	for _, tgt := range tgts {
 		for {
-			var count int
-			if err := crdbPool.QueryRowContext(ctx,
-				fmt.Sprintf("SELECT count(*) FROM %s WHERE %s = 'updated'", tgt, crdbCol)).Scan(&count); !a.NoError(err) {
-				return
-			}
+			count, err := base.GetRowCountWithPredicate(ctx, fixture.TargetPool, tgt, fmt.Sprintf("%s = 'updated'", crdbCol))
+			r.NoError(err)
 			log.Trace("update count", count)
 			if count == rowCount {
 				break
@@ -283,11 +280,8 @@ func testPGLogical(t *testing.T, fc *fixtureConfig) {
 	// Wait for the deletes to propagate.
 	for _, tgt := range tgts {
 		for {
-			var count int
-			if err := crdbPool.QueryRowContext(ctx,
-				fmt.Sprintf("SELECT count(*) FROM %s WHERE %s = 'updated'", tgt, crdbCol)).Scan(&count); !a.NoError(err) {
-				return
-			}
+			count, err := base.GetRowCountWithPredicate(ctx, fixture.TargetPool, tgt, fmt.Sprintf("%s = 'updated'", crdbCol))
+			r.NoError(err)
 			log.Trace("delete count", count)
 			if count == rowCount-50 {
 				break

--- a/internal/target/apply/apply_test.go
+++ b/internal/target/apply/apply_test.go
@@ -88,26 +88,9 @@ func TestApply(t *testing.T) {
 		return
 	}
 
-	// A helper to count the number of rows where has_default = lookFor.
-	// https://github.com/cockroachdb/replicator/issues/689
 	countHasDefault := func(lookFor string) (ct int, err error) {
-		var q string
-		switch fixture.TargetPool.Product {
-		case types.ProductCockroachDB, types.ProductPostgreSQL:
-			q = "SELECT count(*) FROM %s WHERE has_default=$1"
-		case types.ProductMariaDB, types.ProductMySQL:
-			q = "SELECT count(*) FROM %s WHERE has_default=?"
-		case types.ProductOracle:
-			q = "SELECT count(*) FROM %s WHERE has_default=:p1"
-		default:
-			panic("unimplemented")
-		}
-
-		err = fixture.TargetPool.QueryRowContext(ctx,
-			fmt.Sprintf(q, tbl.Name()),
-			lookFor,
-		).Scan(&ct)
-		return
+		count, err := base.GetRowCountWithPredicate(ctx, fixture.TargetPool, tbl.Name(), fmt.Sprintf("has_default='%s'", lookFor))
+		return count, err
 	}
 
 	// Use this jumbled name when accessing the API.


### PR DESCRIPTION
Previously, product specific switch cases were used to determine how to build a query for the target database in the script test. We want to commonize this to a helper that can take care of the product specific logic and execute the query to find the row counts based on predicate.

Integrated this into the script test after implementing.

Resolves: #689
Release Note: None

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/1032)
<!-- Reviewable:end -->
