### PR TITLE
stage: updated the MarkApplied so that table updates happen in batches

### DIFF
--- a/internal/staging/stage/stage.go
+++ b/internal/staging/stage/stage.go
@@ -43,6 +43,10 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// defaultMarkApppliedBatchSize is the default number of mutations to mark
+// applied in the staging table at once.
+const defaultMarkAppliedBatchSize = 100_000
+
 // This mutation value will be stored when a mutation is marked as
 // having been applied without having been previously staged.
 var stubSentinel = json.RawMessage(`{"__stub__":true}`)
@@ -59,9 +63,10 @@ func stagingTable(stagingDB ident.Schema, target ident.Table) ident.Table {
 // Mutation instances.
 type stage struct {
 	// The staging table that holds the mutations.
-	stage      *ident.Hinted[ident.Table]
-	stagingDB  *types.StagingPool
-	retireFrom notify.Var[hlc.Time] // Makes subsequent calls to Retire() a bit faster.
+	stage                *ident.Hinted[ident.Table]
+	stagingDB            *types.StagingPool
+	retireFrom           notify.Var[hlc.Time] // Makes subsequent calls to Retire() a bit faster.
+	markAppliedBatchSize int
 
 	consistencyError prometheus.Gauge
 	filterApplied    prometheus.Observer
@@ -161,22 +166,23 @@ ALTER TABLE %s ADD COLUMN IF NOT EXISTS deletion BOOL NULL
 
 	labels := metrics.TableValues(target)
 	s := &stage{
-		stage:            db.HintNoFTS(table),
-		stagingDB:        db,
-		consistencyError: stageConsistencyErrors.WithLabelValues(labels...),
-		filterApplied:    stageFilterAppliedDuration.WithLabelValues(labels...),
-		filterCount:      stageFilterCount.WithLabelValues(labels...),
-		markDuration:     stageMarkDuration.WithLabelValues(labels...),
-		retireDuration:   stageRetireDurations.WithLabelValues(labels...),
-		retireError:      stageRetireErrors.WithLabelValues(labels...),
-		selectCount:      stageSelectCount.WithLabelValues(labels...),
-		selectDuration:   stageSelectDurations.WithLabelValues(labels...),
-		selectError:      stageSelectErrors.WithLabelValues(labels...),
-		staleCount:       stageStaleMutations.WithLabelValues(labels...),
-		stageCount:       stageCount.WithLabelValues(labels...),
-		stageDupes:       stageDuplicateCount.WithLabelValues(labels...),
-		stageDuration:    stageDuration.WithLabelValues(labels...),
-		stageError:       stageErrors.WithLabelValues(labels...),
+		stage:                db.HintNoFTS(table),
+		stagingDB:            db,
+		markAppliedBatchSize: defaultMarkAppliedBatchSize,
+		consistencyError:     stageConsistencyErrors.WithLabelValues(labels...),
+		filterApplied:        stageFilterAppliedDuration.WithLabelValues(labels...),
+		filterCount:          stageFilterCount.WithLabelValues(labels...),
+		markDuration:         stageMarkDuration.WithLabelValues(labels...),
+		retireDuration:       stageRetireDurations.WithLabelValues(labels...),
+		retireError:          stageRetireErrors.WithLabelValues(labels...),
+		selectCount:          stageSelectCount.WithLabelValues(labels...),
+		selectDuration:       stageSelectDurations.WithLabelValues(labels...),
+		selectError:          stageSelectErrors.WithLabelValues(labels...),
+		staleCount:           stageStaleMutations.WithLabelValues(labels...),
+		stageCount:           stageCount.WithLabelValues(labels...),
+		stageDupes:           stageDuplicateCount.WithLabelValues(labels...),
+		stageDuration:        stageDuration.WithLabelValues(labels...),
+		stageError:           stageErrors.WithLabelValues(labels...),
 	}
 
 	// Prevent these hot-path queries from being planned with a full
@@ -551,6 +557,12 @@ func (s *stage) stageOneBatch(
 	return nil
 }
 
+// SetMarkAppliedBatchSize is used for testing and helps set the mark applied
+// batch size so we can verify the behavior of different batch sizes.
+func (s *stage) SetMarkAppliedBatchSize(size int) {
+	s.markAppliedBatchSize = size
+}
+
 const markAppliedTemplate = `
 WITH t (key, nanos, logical) AS (SELECT unnest($1::STRING[]), unnest($2::INT8[]), unnest($3::INT8[]))
 INSERT INTO %s (key, nanos, logical, applied, applied_at, mut)
@@ -575,8 +587,15 @@ func (s *stage) MarkApplied(
 	return retry.Retry(ctx, s.stagingDB, func(ctx context.Context) error {
 		start := time.Now()
 
+		// 1) number of mutations larger than the `markAppliedBatchSize`: we
+		// want to introduce a transaction here to keep the updates for a
+		// batch's apply times atomic. However, we only want to do this if there
+		// is not already a transaction.
+		//
+		// 2) extraSanityChecks: we need a transaction in order to check if the
+		// data is consistent.
 		var tx pgx.Tx
-		if extraSanityChecks {
+		if extraSanityChecks || len(muts) > s.markAppliedBatchSize {
 			if _, isTx := db.(pgx.Tx); !isTx {
 				var err error
 				tx, err = s.stagingDB.Begin(ctx)
@@ -588,10 +607,32 @@ func (s *stage) MarkApplied(
 			}
 		}
 
-		tag, err := db.Exec(ctx, s.sql.markApplied, keys, nanos, logical)
-		if err != nil {
-			return errors.Wrap(err, s.sql.markApplied)
+		// Applies the mutations in batches to avoid exceeding the
+		// `sql.conn.max_read_buffer_message_size` This also reduces
+		// the memory being used during this step in the case there
+		// are millions or more rows.
+		if err := batches.Window(s.markAppliedBatchSize, len(muts), func(begin, end int) error {
+			lenWindow := end - begin
+			keys := make([]json.RawMessage, lenWindow)
+			nanos := make([]int64, lenWindow)
+			logical := make([]int, lenWindow)
+			for idx, mut := range muts[begin:end] {
+				keys[idx] = mut.Key
+				nanos[idx] = mut.Time.Nanos()
+				logical[idx] = mut.Time.Logical()
+			}
+
+			tag, err := db.Exec(ctx, s.sql.markApplied, keys, nanos, logical)
+			if err != nil {
+				return errors.Wrap(err, s.sql.markApplied)
+			}
+
+			log.Tracef("MarkApplied: %s marked %d mutations", s.stage, tag.RowsAffected())
+			return nil
+		}); err != nil {
+			return err
 		}
+
 		if extraSanityChecks {
 			count, err := s.CheckConsistency(ctx, db, muts, false /* current-time read */)
 			if err != nil {
@@ -602,7 +643,6 @@ func (s *stage) MarkApplied(
 			}
 		}
 		s.markDuration.Observe(time.Since(start).Seconds())
-		log.Tracef("MarkApplied: %s marked %d mutations", s.stage, tag.RowsAffected())
 		if tx != nil {
 			return errors.WithStack(tx.Commit(ctx))
 		}

--- a/internal/staging/stage/stage_test.go
+++ b/internal/staging/stage/stage_test.go
@@ -83,6 +83,37 @@ func TestFilterStubs(t *testing.T) {
 
 // TestPutAndDrain will insert and mark a batch of Mutations.
 func TestPutAndDrain(t *testing.T) {
+	tc := []struct {
+		name           string
+		totalMutations int
+		batchSize      int
+	}{
+		{
+			name:           "batch is larger than total mutations",
+			totalMutations: 500,
+			batchSize:      1_000,
+		},
+		{
+			name:           "full batches only",
+			totalMutations: 1_000,
+			batchSize:      500,
+		},
+		{
+			name:           "full batches and partial batch",
+			totalMutations: 1_200,
+			batchSize:      500,
+		},
+	}
+
+	for _, tc := range tc {
+		t.Run(tc.name, func(t *testing.T) {
+			testPutAndDrain(t, tc.totalMutations, tc.batchSize)
+		})
+	}
+
+}
+
+func testPutAndDrain(t *testing.T, total int, testBatchSize int) {
 	a := assert.New(t)
 	r := require.New(t)
 
@@ -106,6 +137,11 @@ func TestPutAndDrain(t *testing.T) {
 			ctx context.Context, db types.StagingQuerier, before hlc.Time, aost bool,
 		) (int, error)
 	})
+	batcher := s.(interface {
+		SetMarkAppliedBatchSize(size int)
+	})
+	// Set the batch size before staging.
+	batcher.SetMarkAppliedBatchSize(testBatchSize)
 
 	jumbledStager, err := fixture.Stagers.Get(ctx, sinktest.JumbleTable(dummyTarget))
 	r.NoError(err)
@@ -115,7 +151,6 @@ func TestPutAndDrain(t *testing.T) {
 	stagingTable := s.(interface{ GetTable() ident.Table }).GetTable()
 
 	// Cook test data.
-	const total = 10_000
 	muts := make([]types.Mutation, total)
 	for i := range muts {
 		muts[i] = types.Mutation{


### PR DESCRIPTION
Integrate the batches.Window functionality from `util.Batches` to split up the work for MarkApplied in order to address concerns with sending payloads that exceed the sql.conn.max_read_buffer_message_size.

The new logic handles the processing of the mutations inside of batches.Window and sets the default window size to 100,000.

Resolves: #995
Release Note: None

**Testing**
- Hardcoded in a batch size of 1
- Inserted in 4 rows
- Verified that they get applied in individual batches
```
DEBUG  [Oct  1 17:45:13] MarkApplied: "_replicator"."public"."molt_public_tbl1"@{NO_FULL_SCAN} marked 1 mutations 
DEBUG  [Oct  1 17:45:15]                                               httpRequest="&{0x14000611c20 45 200 3 4.961584ms   false false}"
DEBUG  [Oct  1 17:45:15] upserted rows                                 conflicts=0 duration=1.053291ms proposed=1 target="\"molt\".\"public\".\"tbl1\"" upserted=1
DEBUG  [Oct  1 17:45:15] MarkApplied: "_replicator"."public"."molt_public_tbl1"@{NO_FULL_SCAN} marked 1 mutations 
DEBUG  [Oct  1 17:45:16] staged mutations                              count=1 duration=4.098209ms target="\"_replicator\".\"public\".\"molt_public_tbl1\"@{NO_FULL_SCAN}"
DEBUG  [Oct  1 17:45:16]                                               httpRequest="&{0x140006fc6c0 125 200 3 4.272833ms   false false}"
DEBUG  [Oct  1 17:45:18]                                               httpRequest="&{0x140006fcb40 45 200 3 3.637875ms   false false}"
DEBUG  [Oct  1 17:45:18] upserted rows                                 conflicts=0 duration="807.875µs" proposed=1 target="\"molt\".\"public\".\"tbl1\"" upserted=1
DEBUG  [Oct  1 17:45:18] MarkApplied: "_replicator"."public"."molt_public_tbl1"@{NO_FULL_SCAN} marked 1 mutations 
DEBUG  [Oct  1 17:45:21]                                               httpRequest="&{0x140006fd7a0 45 200 3 4.040834ms   false false}"
DEBUG  [Oct  1 17:45:21] upserted rows                                 conflicts=0 duration=1.278084ms proposed=1 target="\"molt\".\"public\".\"tbl1\"" upserted=1
DEBUG  [Oct  1 17:45:21] MarkApplied: "_replicator"."public"."molt_public_tbl1"@{NO_FULL_SCAN} marked 1 mutations 
DEBUG  [Oct  1 17:45:24]                                               httpRequest="&{0x140008198c0 45 200 3 4.716833ms   false false}"
DEBUG  [Oct  1 17:45:27]                                               httpRequest="&{0x1400061a120 45 200 3 5.514375ms   false false}"
```
- Verified that the table ends up with mark applied
```
root@127.0.0.1:26257/_replicator> SELECT * FROM molt_public_tbl1;                                                                    
         nanos        | logical |     key     |                         mut                          | before | applied |          applied_at           | deletion |          source_time
----------------------+---------+-------------+------------------------------------------------------+--------+---------+-------------------------------+----------+--------------------------------
  1727829869833460550 |       0 | [1204568]   | \x7b226964223a313230343536382c2274223a22796f227d     | NULL   |    t    | 2024-10-02 00:44:36.032538+00 |    f     | 2024-10-02 00:44:29.83346+00
  1727829908772441943 |       0 | [1204560]   | \x7b226964223a313230343536302c2274223a22796f227d     | NULL   |    t    | 2024-10-02 00:45:13.415785+00 |    f     | 2024-10-02 00:45:08.772442+00
  1727829910926786528 |       0 | [12045601]  | \x7b226964223a31323034353630312c2274223a22796f227d   | NULL   |    t    | 2024-10-02 00:45:15.030812+00 |    f     | 2024-10-02 00:45:10.926787+00
  1727829913129158195 |       0 | [12045604]  | \x7b226964223a31323034353630342c2274223a22796f227d   | NULL   |    t    | 2024-10-02 00:45:18.032043+00 |    f     | 2024-10-02 00:45:13.129158+00
  1727829915248298738 |       0 | [120456046] | \x7b226964223a3132303435363034362c2274223a22796f227d | NULL   |    t    | 2024-10-02 00:45:21.031444+00 |    f     | 2024-10-02 00:45:15.248299+00
(5 rows)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/1033)
<!-- Reviewable:end -->
