### PR TITLE
cdc: Capture the stack of panics in the HTTP handler

### DIFF
--- a/internal/source/cdc/handler.go
+++ b/internal/source/cdc/handler.go
@@ -72,7 +72,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		if thrown := recover(); thrown != nil {
 			err, ok := thrown.(error)
-			if !ok {
+			if ok {
+				// The stack is currently at the site of the panic.
+				err = errors.WithStack(err)
+			} else {
 				err = errors.Errorf("unexpected error: %v", thrown)
 			}
 			sendErr(err)


### PR DESCRIPTION
This change improves error reporting if a panic occurs during an HTTP request. A recovering deferred function is invoked by the runtime at the site of the panic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/1034)
<!-- Reviewable:end -->
