### PR TITLE
ident: made the empty table logging more clear when the CDC query webhook URI doesn't contain the table

### DIFF
--- a/internal/source/cdc/webhook.go
+++ b/internal/source/cdc/webhook.go
@@ -114,8 +114,9 @@ func (h *Handler) webhook(ctx context.Context, req *request) error {
 			return err
 		}
 
-		// In the webhook case, if the payload topic is that means the table was
-		// not passed in properly.
+		// If the topic is empty, we have received a CDC query payload and the
+		// user has not specified a three-segment request path to set a table
+		// name.
 		if payload.Payload[i].Topic == "" {
 			return errors.New("table name is empty, please ensure the table name is included in the path")
 		}

--- a/internal/source/cdc/webhook.go
+++ b/internal/source/cdc/webhook.go
@@ -114,6 +114,12 @@ func (h *Handler) webhook(ctx context.Context, req *request) error {
 			return err
 		}
 
+		// In the webhook case, if the payload topic is that means the table was
+		// not passed in properly.
+		if payload.Payload[i].Topic == "" {
+			return errors.New("table name is empty, please ensure the table name is included in the path")
+		}
+
 		table, qual, err := ident.ParseTableRelative(payload.Payload[i].Topic, req.target.Schema())
 		if err != nil {
 			return err


### PR DESCRIPTION
Resolves: #720
Release Note: None

**Testing**
```
go test -v -run ^TestIntegration$ github.com/cockroachdb/replicator/internal/source/cdc/server | tee test.log
...
{
  "error": "table name is empty, please ensure the table name is included in the path",
  "severity": "ERROR",
  "timestamp": {
    "seconds": 1728000632,
    "nanos": 377887000
  },
  "uri": "/tgt-74858-58/public"
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/1035)
<!-- Reviewable:end -->
