### PR TITLE
conveyor/config: added new configuration for skipping backwards data checks

### DIFF
--- a/internal/conveyor/config.go
+++ b/internal/conveyor/config.go
@@ -54,6 +54,11 @@ type Config struct {
 	// (e.g. running into a lock), but will cause replication to stall
 	// if behind by this many checkpoints.
 	LimitLookahead int
+
+	// If set, skips the data check that determines if data is moving
+	// in a backwards direction. There are situations where customers
+	// may want to skip this check.
+	SkipBackwardsDataCheck bool
 }
 
 // Bind adds configuration flags to the set.
@@ -71,6 +76,16 @@ func (c *Config) Bind(f *pflag.FlagSet) {
 	f.IntVar(&c.LimitLookahead, "limitLookahead", 0,
 		"limit number of checkpoints to be considered when computing the resolving range; "+
 			"may cause replication to stall completely if older mutations cannot be applied")
+	f.BoolVar(&c.SkipBackwardsDataCheck, "ignoreBackwardsCheck", false,
+		"skip checks for data moving backwards")
+
+	// Marking this ignore check functionality as hidden in order to not
+	// encourage customers to use this option since it disables a critical check
+	// that data is moving backwards. This should be made known to customers on
+	// an as-needed basis.
+	if err := f.MarkHidden("ignoreBackwardsCheck"); err != nil {
+		panic(err)
+	}
 }
 
 // Preflight ensures the Config is in a known-good state.

--- a/internal/conveyor/conveyor.go
+++ b/internal/conveyor/conveyor.go
@@ -102,6 +102,10 @@ func (c *Conveyors) Get(schema ident.Schema) (*Conveyor, error) {
 	if l := c.cfg.LimitLookahead; l > 0 {
 		opts = append(opts, checkpoint.LimitLookahead(l))
 	}
+	if s := c.cfg.SkipBackwardsDataCheck; s {
+		opts = append(opts, checkpoint.SkipBackwardsDataCheck())
+	}
+
 	ret.checkpoint, err = c.checkpoints.Start(c.stopper, tableGroup, &ret.resolvingRange, opts...)
 	if err != nil {
 		return nil, err

--- a/internal/staging/checkpoint/checkpoint.go
+++ b/internal/staging/checkpoint/checkpoint.go
@@ -45,6 +45,7 @@ type Checkpoints struct {
 func (r *Checkpoints) Start(
 	ctx *stopper.Context, group *types.TableGroup, bounds *notify.Var[hlc.Range], options ...Option,
 ) (*Group, error) {
+	var ignoreBackwardsCheck bool
 	var lookahead int
 	useStream := true
 	for _, opt := range options {
@@ -56,9 +57,11 @@ func (r *Checkpoints) Start(
 			if lookahead <= 0 {
 				return nil, errors.New("lookahead must be greater than zero")
 			}
+		case skipBackwardsDataCheck:
+			ignoreBackwardsCheck = true
 		}
 	}
-	ret := r.newGroup(group, bounds, lookahead)
+	ret := r.newGroup(group, bounds, lookahead, ignoreBackwardsCheck)
 	// Populate data immediately.
 	if err := ret.refreshBounds(ctx); err != nil {
 		return nil, err
@@ -73,12 +76,13 @@ func (r *Checkpoints) Start(
 }
 
 func (r *Checkpoints) newGroup(
-	group *types.TableGroup, bounds *notify.Var[hlc.Range], lookahead int,
+	group *types.TableGroup, bounds *notify.Var[hlc.Range], lookahead int, ignoreBackwardsCheck bool,
 ) *Group {
 	ret := &Group{
-		bounds: bounds,
-		pool:   r.pool,
-		target: group,
+		bounds:               bounds,
+		ignoreBackwardsCheck: ignoreBackwardsCheck,
+		pool:                 r.pool,
+		target:               group,
 	}
 
 	labels := prometheus.Labels{"schema": group.Name.Raw()}

--- a/internal/staging/checkpoint/migrate_test.go
+++ b/internal/staging/checkpoint/migrate_test.go
@@ -85,6 +85,7 @@ INSERT INTO %s (target_schema, source_nanos, source_logical, target_applied_at) 
 			},
 			notify.VarOf(hlc.RangeEmpty()),
 			1024,
+			false, /* ignoreBackwardsCheck */
 		).refreshQuery(ctx, hlc.Zero())
 		r.NoError(err)
 		r.Equal(expect, rng)

--- a/internal/staging/checkpoint/options.go
+++ b/internal/staging/checkpoint/options.go
@@ -40,3 +40,13 @@ func LimitLookahead(limit int) Option {
 }
 
 func (l limitLookahead) isOption() {}
+
+type skipBackwardsDataCheck struct{}
+
+// SkipBackwardsDataCheck disables the error check for when
+// data is moving backwards.
+func SkipBackwardsDataCheck() Option {
+	return skipBackwardsDataCheck{}
+}
+
+func (s skipBackwardsDataCheck) isOption() {}


### PR DESCRIPTION
Previously, customers manually had to skip backwards data checks by updating source code. This change makes it so that they can now pass in a flag to control the behavior of if they want to perform that check or not.

Resolves: #1046
Release Note: new flag that controls if the backwards data check can be skipped

**TODO**
- [x] Hide the flag from customers
- [x] Add automated testing

**Local Testing**
When the `--ignoreBackwardsCheck` is specified (added debug logging for this then reverted). We verified above we can still invoke it to set it.
```
time="Oct 23 15:48:17" level=debug httpRequest="&{0x140004bea00 45 200 3 3.617709ms   false false}"
ignore check:  true
```

**Flag is hidden from help output**
```
      --httpResponseTimeout duration   the maximum amount of time to allow an HTTP handler to execute for (default 2m0s)
      --immediate                      bypass staging tables and write directly to target; recommended only for KV-style workloads with no FKs
      --limitLookahead int             limit number of checkpoints to be considered when computing the resolving range; may cause replication to stall completely if older mutations cannot be applied
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/1052)
<!-- Reviewable:end -->
