### PR TITLE
sequtil: Remove extraneous return statement from LeaseGroup

### DIFF
--- a/internal/sequencer/sequtil/lease_group.go
+++ b/internal/sequencer/sequtil/lease_group.go
@@ -113,7 +113,6 @@ func LeaseGroup(
 						entry.Debug("restarting")
 					}
 				})
-			return nil
 		}
 		return nil
 	})

--- a/internal/sequencer/sequtil/lease_group_test.go
+++ b/internal/sequencer/sequtil/lease_group_test.go
@@ -1,0 +1,72 @@
+// Copyright 2024 The Cockroach Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package sequtil
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/field-eng-powertools/stopper"
+	"github.com/cockroachdb/replicator/internal/sinktest/all"
+	"github.com/cockroachdb/replicator/internal/types"
+	"github.com/cockroachdb/replicator/internal/util/ident"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRecreateLease ensures that LeaseGroup will restart if the
+// acquired lease is lost.
+func TestLeaseGroupExpiration(t *testing.T) {
+	r := require.New(t)
+
+	fixture, err := all.NewFixture(t)
+	r.NoError(err)
+	outer := fixture.Context
+
+	var count atomic.Int32
+	LeaseGroup(fixture.Context,
+		fixture.Leases,
+		time.Second, /* grace period */
+		&types.TableGroup{
+			Enclosing: fixture.TargetSchema.Schema(),
+			Name:      ident.New("test"),
+			Tables: []ident.Table{
+				ident.NewTable(fixture.TargetSchema.Schema(), ident.New("test")),
+			},
+		},
+		func(nested *stopper.Context, _ *types.TableGroup) {
+			r.NotSame(outer, nested)
+
+			switch count.Add(1) {
+			case 1:
+				// Retrieve the associated lease.
+				lease, ok := nested.Value(types.LeaseKey{}).(types.Lease)
+				r.True(ok)
+				// This will cause the nested context to be canceled.
+				lease.Release()
+				<-nested.Stopping()
+			case 2:
+				// This will prevent another loop.
+				outer.Stop(time.Second)
+			default:
+				r.Fail("should be called exactly twice")
+			}
+		})
+
+	r.NoError(outer.Wait())
+	r.Equal(int32(2), count.Load())
+}

--- a/internal/sinktest/all/fixture.go
+++ b/internal/sinktest/all/fixture.go
@@ -50,6 +50,7 @@ type Fixture struct {
 	Diagnostics    *diag.Diagnostics
 	DLQConfig      *dlq.Config
 	DLQs           types.DLQs
+	Leases         types.Leases
 	Loader         *load.Loader
 	Memo           types.Memo
 	Stagers        types.Stagers

--- a/internal/sinktest/all/wire_gen.go
+++ b/internal/sinktest/all/wire_gen.go
@@ -9,6 +9,7 @@ package all
 import (
 	"github.com/cockroachdb/replicator/internal/sinktest/base"
 	"github.com/cockroachdb/replicator/internal/staging/checkpoint"
+	"github.com/cockroachdb/replicator/internal/staging/leases"
 	"github.com/cockroachdb/replicator/internal/staging/memo"
 	"github.com/cockroachdb/replicator/internal/staging/stage"
 	"github.com/cockroachdb/replicator/internal/staging/version"
@@ -93,6 +94,10 @@ func NewFixture(t testing.TB) (*Fixture, error) {
 	if err != nil {
 		return nil, err
 	}
+	typesLeases, err := leases.ProvideLeases(context, stagingPool, stagingSchema)
+	if err != nil {
+		return nil, err
+	}
 	stagers := stage.ProvideFactory(stagingPool, stagingSchema, context)
 	checker := version.ProvideChecker(stagingPool, memoMemo)
 	watcher, err := ProvideWatcher(targetSchema, watchers)
@@ -107,6 +112,7 @@ func NewFixture(t testing.TB) (*Fixture, error) {
 		Diagnostics:    diagnostics,
 		DLQConfig:      config,
 		DLQs:           dlQs,
+		Leases:         typesLeases,
 		Loader:         loader,
 		Memo:           memoMemo,
 		Stagers:        stagers,
@@ -155,6 +161,10 @@ func NewFixtureFromBase(fixture *base.Fixture) (*Fixture, error) {
 	if err != nil {
 		return nil, err
 	}
+	typesLeases, err := leases.ProvideLeases(context, stagingPool, stagingSchema)
+	if err != nil {
+		return nil, err
+	}
 	stagers := stage.ProvideFactory(stagingPool, stagingSchema, context)
 	checker := version.ProvideChecker(stagingPool, memoMemo)
 	targetSchema := fixture.TargetSchema
@@ -170,6 +180,7 @@ func NewFixtureFromBase(fixture *base.Fixture) (*Fixture, error) {
 		Diagnostics:    diagnostics,
 		DLQConfig:      config,
 		DLQs:           dlQs,
+		Leases:         typesLeases,
 		Loader:         loader,
 		Memo:           memoMemo,
 		Stagers:        stagers,

--- a/internal/staging/leases/leases.go
+++ b/internal/staging/leases/leases.go
@@ -179,8 +179,9 @@ func (l *leases) Acquire(ctx context.Context, names ...string) (types.Lease, err
 			_, _ = l.release(context.Background(), leaseRow)
 			cancel()
 		},
-		ctx: ctx,
 	}
+	// Export the lease for testing purposes.
+	ret.ctx = context.WithValue(ctx, types.LeaseKey{}, types.Lease(ret))
 
 	runtime.SetFinalizer(ret, func(f *leaseFacade) { f.Release() })
 

--- a/internal/staging/leases/leases_test.go
+++ b/internal/staging/leases/leases_test.go
@@ -312,6 +312,9 @@ func TestLeases(t *testing.T) {
 		// Initial acquisition.
 		facade, err := l.Acquire(ctx, t.Name())
 		a.NoError(err)
+		found, ok := facade.Context().Value(types.LeaseKey{}).(types.Lease)
+		a.True(ok)
+		a.Same(facade, found)
 
 		// Verify that a duplicate fails.
 		_, err = l.Acquire(ctx, t.Name())

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -88,6 +88,9 @@ func IsLeaseBusy(err error) (busy *LeaseBusyError, ok bool) {
 	return busy, errors.As(err, &busy)
 }
 
+// LeaseKey may be used to retrieve a Lease from its [context.Context].
+type LeaseKey struct{}
+
 // Leases coordinates behavior across multiple instances of Replicator.
 type Leases interface {
 	// Acquire the named leases in an all-or-nothing fashion. A


### PR DESCRIPTION
This change removes a copy-pasto that will cause LeaseGroup to exit if the underlying lease expires. The bulk of this change is allowing a test to access the Lease instance by way of Context.Value().

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/replicator/1054)
<!-- Reviewable:end -->
